### PR TITLE
Add optional update notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -73,6 +73,8 @@ enum Commands {
         #[command(subcommand)]
         command: HookCommands,
     },
+    /// Check for a newer ForgeGuard release (optional; never required).
+    Update,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -161,6 +163,9 @@ fn execute() -> Result<ExitCode> {
                     print!("{}", render_detection(&report.detection));
                 }
             }
+            if !json {
+                print_update_notice();
+            }
             Ok(ExitCode::SUCCESS)
         }
         Commands::Detect { json } => {
@@ -183,6 +188,7 @@ fn execute() -> Result<ExitCode> {
                 println!("{}", serde_json::to_string_pretty(&report)?);
             } else {
                 print!("{}", render_doctor(&report));
+                print_update_notice();
             }
             Ok(if report.healthy {
                 ExitCode::SUCCESS
@@ -234,6 +240,17 @@ fn execute() -> Result<ExitCode> {
         Commands::Hook {
             command: HookCommands::Stop { agent },
         } => execute_stop_hook(&root, agent.into()),
+        Commands::Update => {
+            let home = home_directory()?;
+            match forgeguard_core::update::refresh(&home, true) {
+                Some(notice) => println!("{notice}"),
+                None => println!(
+                    "ForgeGuard {} is up to date.",
+                    forgeguard_core::update::current_version()
+                ),
+            }
+            Ok(ExitCode::SUCCESS)
+        }
     }
 }
 
@@ -242,6 +259,10 @@ fn execute_stop_hook(root: &std::path::Path, agent: HookAgent) -> Result<ExitCod
     std::io::stdin()
         .read_to_string(&mut input)
         .context("failed to read hook input")?;
+    let home = home_directory().ok();
+    if let Some(home) = &home {
+        forgeguard_core::update::spawn_refresh_if_stale(home);
+    }
     let decision = match evaluate_stop_hook(root, &input) {
         Ok((decision, _cache_hit)) => decision,
         Err(error) => {
@@ -252,11 +273,34 @@ fn execute_stop_hook(root: &std::path::Path, agent: HookAgent) -> Result<ExitCod
             ))
         }
     };
+    // A passing gate stays silent; only surface the optional notice when the hook
+    // is already returning feedback, so clean turns keep zero noise.
+    let decision = match decision {
+        HookDecision::Block(reason) => {
+            HookDecision::Block(append_update_notice(reason, home.as_deref()))
+        }
+        HookDecision::Pass => HookDecision::Pass,
+    };
     let output = render_hook_decision(agent, &decision);
     if !output.is_empty() {
         println!("{output}");
     }
     Ok(ExitCode::SUCCESS)
+}
+
+fn append_update_notice(reason: String, home: Option<&std::path::Path>) -> String {
+    match home.and_then(forgeguard_core::update::cached_notice) {
+        Some(notice) => format!("{reason}\n\n{notice}"),
+        None => reason,
+    }
+}
+
+fn print_update_notice() {
+    if let Ok(home) = home_directory() {
+        if let Some(notice) = forgeguard_core::update::refresh(&home, false) {
+            println!("{notice}");
+        }
+    }
 }
 
 fn render_gate_output(report: &GateReport, json: bool, output: OutputArg) -> Result<()> {

--- a/crates/forgeguard-core/src/lib.rs
+++ b/crates/forgeguard-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod model;
 pub mod report;
 pub mod runner;
 pub mod scanner;
+pub mod update;
 
 pub use config::{CommandConfig, ForgeGuardConfig, GuardMode};
 pub use detector::{detect_project, ProjectDetection};

--- a/crates/forgeguard-core/src/update.rs
+++ b/crates/forgeguard-core/src/update.rs
@@ -1,0 +1,170 @@
+//! Optional, non-blocking update notifications.
+//!
+//! The hot path (the Stop hook) only ever reads a local cache, so it makes no
+//! network call and adds no latency. A stale cache is refreshed by a detached
+//! background process, and `doctor`/`init` refresh it in the foreground. The
+//! latest release is discovered with `git ls-remote` so no HTTP dependency,
+//! API token, or rate-limited endpoint is required.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+
+const REPOSITORY_URL: &str = "https://github.com/suiflex/ForgeGuard";
+const CACHE_RELATIVE: &str = ".forgeguard/update-check.json";
+const INSTALL_COMMAND: &str =
+    "curl -fsSL https://raw.githubusercontent.com/suiflex/ForgeGuard/main/install.sh | sh";
+const THROTTLE_SECONDS: u64 = 86_400;
+
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UpdateCache {
+    checked_at: u64,
+    latest: String,
+}
+
+/// One-line optional notice built from the cached latest version. Never touches
+/// the network; safe to call on every hook invocation.
+pub fn cached_notice(home: &Path) -> Option<String> {
+    let cache = read_cache(home)?;
+    notice(current_version(), &cache.latest)
+}
+
+/// Refresh the cache when it is stale (or always when `force`), then return the
+/// current notice. Performs a network lookup only when a refresh is due. Used by
+/// `doctor`, `init`, and the detached `update` command.
+pub fn refresh(home: &Path, force: bool) -> Option<String> {
+    if force || is_stale(home) {
+        if let Some(latest) = fetch_latest_version() {
+            write_cache(
+                home,
+                &UpdateCache {
+                    checked_at: now_seconds(),
+                    latest,
+                },
+            );
+        }
+    }
+    cached_notice(home)
+}
+
+/// Launch a detached refresh when the cache is missing or older than the
+/// throttle window. Fire-and-forget: the caller is never blocked and no output
+/// is inherited, so the hook stays fast and silent.
+pub fn spawn_refresh_if_stale(home: &Path) {
+    if !is_stale(home) {
+        return;
+    }
+    let Ok(executable) = std::env::current_exe() else {
+        return;
+    };
+    let _ = Command::new(executable)
+        .arg("update")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+}
+
+fn is_stale(home: &Path) -> bool {
+    match read_cache(home) {
+        Some(cache) => now_seconds().saturating_sub(cache.checked_at) >= THROTTLE_SECONDS,
+        None => true,
+    }
+}
+
+/// Discover the highest `vX.Y.Z` release tag via `git ls-remote`.
+fn fetch_latest_version() -> Option<String> {
+    let output = Command::new("git")
+        .args(["ls-remote", "--tags", "--refs", REPOSITORY_URL])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.rsplit("refs/tags/").next())
+        .filter_map(|tag| parse_version(tag.strip_prefix('v').unwrap_or(tag)))
+        .max()
+        .map(|(major, minor, patch)| format!("{major}.{minor}.{patch}"))
+}
+
+fn notice(current: &str, latest: &str) -> Option<String> {
+    if parse_version(latest)? > parse_version(current)? {
+        Some(format!(
+            "Optional: ForgeGuard {latest} is available (current {current}). Update: {INSTALL_COMMAND}"
+        ))
+    } else {
+        None
+    }
+}
+
+fn parse_version(value: &str) -> Option<(u64, u64, u64)> {
+    let core = value.trim().split(['-', '+']).next()?;
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+fn cache_path(home: &Path) -> PathBuf {
+    home.join(CACHE_RELATIVE)
+}
+
+fn read_cache(home: &Path) -> Option<UpdateCache> {
+    let text = fs::read_to_string(cache_path(home)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn write_cache(home: &Path, cache: &UpdateCache) {
+    let path = cache_path(home);
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if let Ok(text) = serde_json::to_string_pretty(cache) {
+        let _ = fs::write(path, text);
+    }
+}
+
+fn now_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_and_prefixed_and_prerelease_versions() {
+        assert_eq!(parse_version("0.3.0"), Some((0, 3, 0)));
+        assert_eq!(parse_version("1.2"), Some((1, 2, 0)));
+        assert_eq!(parse_version("2.0.1-rc.1"), Some((2, 0, 1)));
+        assert_eq!(parse_version("not-a-version"), None);
+        assert_eq!(parse_version("1.2.3.4"), None);
+    }
+
+    #[test]
+    fn notice_only_appears_for_a_strictly_newer_version() {
+        assert!(notice("0.2.0", "0.3.0").is_some());
+        assert!(notice("0.2.0", "0.2.0").is_none());
+        assert!(notice("0.3.0", "0.2.9").is_none());
+    }
+}

--- a/crates/forgeguard-core/tests/update_test.rs
+++ b/crates/forgeguard-core/tests/update_test.rs
@@ -1,0 +1,38 @@
+use std::fs;
+
+use forgeguard_core::update::{cached_notice, current_version};
+use tempfile::tempdir;
+
+fn write_cache(home: &std::path::Path, latest: &str) {
+    let dir = home.join(".forgeguard");
+    fs::create_dir_all(&dir).expect("create cache dir");
+    fs::write(
+        dir.join("update-check.json"),
+        format!("{{\"checked_at\":0,\"latest\":\"{latest}\"}}"),
+    )
+    .expect("write cache");
+}
+
+#[test]
+fn cached_notice_appears_for_a_newer_release() {
+    let home = tempdir().expect("temp home");
+    write_cache(home.path(), "999.0.0");
+
+    let notice = cached_notice(home.path());
+    assert!(notice.is_some());
+    assert!(notice.unwrap().contains("999.0.0"));
+}
+
+#[test]
+fn cached_notice_is_absent_for_the_current_release() {
+    let home = tempdir().expect("temp home");
+    write_cache(home.path(), current_version());
+
+    assert!(cached_notice(home.path()).is_none());
+}
+
+#[test]
+fn cached_notice_is_absent_without_a_cache() {
+    let home = tempdir().expect("temp home");
+    assert!(cached_notice(home.path()).is_none());
+}


### PR DESCRIPTION
## What

Notify agents when a newer ForgeGuard release exists — optional, never forced, and with zero cost on the gate hot path.

## How

- **Version source:** `git ls-remote --tags` (reuses the existing git dependency — no HTTP crate, no API token, no GitHub rate limit).
- **Cache:** `~/.forgeguard/update-check.json`, throttled to one network lookup per 24h.
- **Stop hook:** reads the cache only (zero network, zero added latency) and spawns a detached refresh when stale. The optional notice is appended **only when the hook already returns feedback (a block)** — a passing gate stays completely silent, preserving the token/usage contract.
- **`doctor` / `init`:** refresh in the foreground and print the notice.
- **`forgeguard update`:** new command to check the latest release on demand.

Bumps workspace version to `0.3.0`.

## Tests

- Unit: version parsing + notice threshold.
- Integration: cached-notice behavior (newer / equal / missing cache).
- Full suite green; `clippy -D warnings` clean; `fmt --check` clean.

## Notes

- Design choice: notice is opportunistic on the hook (only when already emitting feedback) rather than nagging every clean turn. `doctor`/`init` always show it. Say the word if you want it on every passing turn instead.