### PR TITLE
Gate any code repository with zero configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]

--- a/crates/forgeguard-core/src/hook.rs
+++ b/crates/forgeguard-core/src/hook.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 
 use crate::{
     config::{ForgeGuardConfig, CONFIG_FILE},
+    detect_project,
     git::{changed_files, worktree_fingerprint},
     report::{render_gate_compact, COMPACT_MAX_CHARS},
     run_gate, GateOptions, GateStatus,
@@ -71,7 +72,22 @@ pub fn evaluate_stop_hook(fallback_root: &Path, input: &str) -> Result<(HookDeci
         }
     }
 
-    let config = ForgeGuardConfig::load(&root)?;
+    // Explicit config wins; otherwise gate any git repo that contains code using
+    // an auto-detected, in-memory config so no per-repo setup is required.
+    let config = if root.join(CONFIG_FILE).exists() {
+        ForgeGuardConfig::load(&root)?
+    } else {
+        let detection = detect_project(&root)?;
+        if detection.languages.is_empty() {
+            return Ok((HookDecision::Pass, false));
+        }
+        ignore_forgeguard_artifacts(&root)?;
+        let name = root
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("project");
+        ForgeGuardConfig::new(name, detection.suggested_commands)
+    };
     let report = run_gate(
         &root,
         &config,
@@ -129,6 +145,36 @@ pub fn render_hook_decision(agent: HookAgent, decision: &HookDecision) -> String
     }
 }
 
+/// In zero-config mode the gate still writes `cache/` and `reports/` under
+/// `.forgeguard/`. Keep those artifacts out of version control without asking
+/// the user to configure anything: a self-ignoring `.forgeguard/.gitignore`,
+/// plus a `.forgeguard/` entry appended to an existing root `.gitignore`.
+fn ignore_forgeguard_artifacts(root: &Path) -> Result<()> {
+    let marker = root.join(".forgeguard/.gitignore");
+    if !marker.exists() {
+        if let Some(parent) = marker.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&marker, "*\n")?;
+    }
+    let root_ignore = root.join(".gitignore");
+    if root_ignore.is_file() {
+        let current = fs::read_to_string(&root_ignore).unwrap_or_default();
+        let already = current
+            .lines()
+            .any(|line| line.trim().trim_end_matches('/') == ".forgeguard");
+        if !already {
+            let mut updated = current;
+            if !updated.is_empty() && !updated.ends_with('\n') {
+                updated.push('\n');
+            }
+            updated.push_str(".forgeguard/\n");
+            fs::write(&root_ignore, updated)?;
+        }
+    }
+    Ok(())
+}
+
 fn find_project_root(fallback_root: &Path, payload: &Value) -> Option<PathBuf> {
     let mut candidates = Vec::new();
     if let Some(cwd) = payload.get("cwd").and_then(Value::as_str) {
@@ -150,7 +196,7 @@ fn find_project_root(fallback_root: &Path, payload: &Value) -> Option<PathBuf> {
         };
         start
             .ancestors()
-            .find(|path| path.join(CONFIG_FILE).is_file())
+            .find(|path| path.join(".git").exists() || path.join(CONFIG_FILE).is_file())
             .map(Path::to_path_buf)
     })
 }

--- a/crates/forgeguard-core/tests/hook_test.rs
+++ b/crates/forgeguard-core/tests/hook_test.rs
@@ -113,6 +113,53 @@ fn agent_protocols_are_silent_or_structured() {
     );
 }
 
+#[test]
+fn auto_gate_runs_without_config_and_ignores_artifacts() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    // A pre-existing root .gitignore must be appended to, not clobbered.
+    fs::write(directory.path().join(".gitignore"), "node_modules/\n").expect("write gitignore");
+    fs::write(
+        directory.path().join("service.ts"),
+        "for (const user of users) { await db.query('SELECT id FROM users WHERE id = 1'); }\n",
+    )
+    .expect("write source");
+
+    let input = format!(
+        r#"{{"cwd":"{}","executionNum":1}}"#,
+        directory.path().display()
+    );
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("evaluate hook");
+    assert!(matches!(decision, HookDecision::Block(_)));
+
+    // No manual setup, yet artifacts are kept out of version control.
+    let marker = fs::read_to_string(directory.path().join(".forgeguard/.gitignore"))
+        .expect("read forgeguard gitignore");
+    assert_eq!(marker.trim(), "*");
+    let root_ignore =
+        fs::read_to_string(directory.path().join(".gitignore")).expect("read root gitignore");
+    assert!(root_ignore.contains("node_modules/"));
+    assert!(root_ignore
+        .lines()
+        .any(|line| line.trim().trim_end_matches('/') == ".forgeguard"));
+    assert!(!directory.path().join(".forgeguard/config.toml").exists());
+}
+
+#[test]
+fn auto_gate_passes_for_repo_without_code() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    fs::write(directory.path().join("README.md"), "# docs only\n").expect("write readme");
+
+    let input = format!(
+        r#"{{"cwd":"{}","executionNum":1}}"#,
+        directory.path().display()
+    );
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("evaluate hook");
+    assert_eq!(decision, HookDecision::Pass);
+    assert!(!directory.path().join(".forgeguard").exists());
+}
+
 fn git_init(root: &std::path::Path) {
     let status = Command::new("git")
         .args(["init", "--quiet"])


### PR DESCRIPTION
## What

ForgeGuard now behaves like a global tool: drop into any git repo with code and the Stop hook gates it automatically — no `forgeguard init`, no per-repo config, no files committed to the repo.

## How

- The Stop hook resolves the project root from the nearest `.git` **or** an explicit `.forgeguard/config.toml`.
- Explicit config still wins. A repo without one is gated using an **auto-detected, in-memory** config (languages + suggested commands from `detect_project`).
- **Guardrails:** a git repo with no detected code (docs-only) and any non-git directory pass silently — `/tmp`, `/bin`, etc. are never touched or written to.
- The gate writes `cache/` and `reports/` under `.forgeguard/`, so those artifacts are kept out of version control automatically: a self-ignoring `.forgeguard/.gitignore` (`*`) plus a `.forgeguard/` entry appended to an existing root `.gitignore`.

Bumps workspace version to `0.4.0`.

## Tests

- `auto_gate_runs_without_config_and_ignores_artifacts` — no config → gate blocks on a real finding, `.forgeguard/.gitignore` = `*`, root `.gitignore` appended (existing entries preserved), no config file written.
- `auto_gate_passes_for_repo_without_code` — docs-only git repo → Pass, no `.forgeguard` created.
- Full suite green; `clippy -D warnings` clean; `fmt --check` clean.
- E2E verified: fresh git repo with an N+1 → auto-block; non-git dir with code → silent pass, nothing written.