### PR TITLE
feat: interactive init wizard with agent and gitignore selection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in this repo.
+# See https://docs.github.com/articles/about-code-owners
+* @suiflex

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .env
 .env.*
 !.env.example
+.claude
+.agents
+.codex

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,1 @@
-# ForgeGuard
-
-Use the ForgeGuard engineering skill under `crates/forgeguard-core/assets/skills/engineering/` for every code change.
-
-Required cycle: inspect → design → implement → test → review → verify.
-
-Inspect related code, callers, tests, contracts, and schemas first. Reuse proven behavior; avoid speculative global APIs/components. Analyze complexity, queries, concurrency, memory, and failure modes when relevant. Test changed behavior. Before completion, run `forgeguard gate --changed --output compact`, repository checks, and review full diff. Report evidence and remaining risk briefly. Never bypass quality or security controls.
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,27 @@ Use the ForgeGuard engineering skill under `crates/forgeguard-core/assets/skills
 Required cycle: inspect → design → implement → test → review → verify.
 
 Inspect related code, callers, tests, contracts, and schemas first. Reuse proven behavior; avoid speculative global APIs/components. Analyze complexity, queries, concurrency, memory, and failure modes when relevant. Test changed behavior. Before completion, run `forgeguard gate --changed --output compact`, repository checks, and review full diff. Report evidence and remaining risk briefly. Never bypass quality or security controls.
+
+## Layout
+
+- `crates/forgeguard-cli/` — the `forgeguard` binary (clap CLI, wizard, output rendering).
+- `crates/forgeguard-core/` — detection, config, gate, hook, and init logic; also ships the
+  bundled assets (`assets/skills/engineering/`, `assets/templates/`) baked in via `include_str!`.
+
+## Commands
+
+- `forgeguard init` — bootstrap a repo. Run in a terminal with no flags to get an interactive
+  wizard (scope, which agents, and whether to add `.forgeguard/` to `.gitignore`). Non-terminal
+  runs, `--json`, or explicit flags skip the wizard and default to all agents.
+  Flags: `--global` (install under the user home instead of the repo), `--agent <codex|claude|cursor|opencode|antigravity|all>`, `--force` (overwrite + prune legacy skills), `--json`.
+- `forgeguard detect` — report languages, frameworks, DB tooling, tests, and suggested commands.
+- `forgeguard doctor` — check config and required local tools.
+- `forgeguard gate [--changed] [--output full|compact|quiet] [--no-run]` — run static rules + configured quality commands.
+- `forgeguard review` — static rules on changed files only (no command execution).
+- `forgeguard hook stop --agent <...>` — lifecycle adapter the agent stop-hooks invoke.
+- `forgeguard update` — optional release check; never required.
+
+## Supported agents
+
+Codex, Claude, Cursor, OpenCode, Antigravity. Each install writes a policy file, the
+engineering skill, and (where supported) a Stop hook running `forgeguard hook stop --agent <name>`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -144,6 +144,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -169,6 +178,70 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -205,6 +278,7 @@ dependencies = [
  "anyhow",
  "clap",
  "forgeguard-core",
+ "inquire",
  "serde_json",
 ]
 
@@ -235,6 +309,15 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-swift",
  "tree-sitter-typescript",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -300,6 +383,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
+dependencies = [
+ "bitflags",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +421,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +448,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +470,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -370,6 +517,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -401,6 +557,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +586,18 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -449,7 +626,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -482,6 +659,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +706,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -515,6 +740,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -735,6 +969,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +997,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +1026,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.78"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 ignore = "0.4"
+inquire = "0.9"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/forgeguard-cli/Cargo.toml
+++ b/crates/forgeguard-cli/Cargo.toml
@@ -18,5 +18,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+inquire.workspace = true
 serde_json.workspace = true
 forgeguard-core = { path = "../forgeguard-core" }

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -1,4 +1,9 @@
-use std::{env, io::Read, path::PathBuf, process::ExitCode};
+use std::{
+    env,
+    io::{IsTerminal, Read, Write},
+    path::PathBuf,
+    process::ExitCode,
+};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
@@ -35,8 +40,9 @@ enum Commands {
         /// Install rules, skills, and hooks for supported agents under the user directory.
         #[arg(long)]
         global: bool,
-        #[arg(long, value_enum, default_value = "all")]
-        agent: AgentArg,
+        /// Agents to install for. Omit in a terminal to pick interactively.
+        #[arg(long, value_enum)]
+        agent: Option<AgentArg>,
         #[arg(long)]
         json: bool,
     },
@@ -136,11 +142,18 @@ fn execute() -> Result<ExitCode> {
             agent,
             json,
         } => {
-            let options = InitOptions {
-                force,
-                agent: agent.into(),
+            // Interactive wizard only when nothing was specified and we own a
+            // terminal. Explicit flags, --json, or a pipe keep the old behavior
+            // (default `all`) so scripts and CI are never prompted.
+            let interactive =
+                agent.is_none() && !global && !json && std::io::stdout().is_terminal();
+            let (use_global, agents, add_gitignore) = if interactive {
+                run_init_wizard()?
+            } else {
+                (global, vec![agent.unwrap_or(AgentArg::All).into()], false)
             };
-            if global {
+            let options = InitOptions { force, agents };
+            if use_global {
                 let home = home_directory()?;
                 let report = initialize_global(&home, &options)?;
                 if json {
@@ -154,11 +167,17 @@ fn execute() -> Result<ExitCode> {
                 }
             } else {
                 let report = initialize_project(&root, &options)?;
+                if add_gitignore {
+                    forgeguard_core::ignore_forgeguard_artifacts(&root)?;
+                }
                 if json {
                     println!("{}", serde_json::to_string_pretty(&report)?);
                 } else {
                     println!("ForgeGuard initialized at {}", root.display());
                     render_file_changes(&report.files_written, &report.files_skipped);
+                    if add_gitignore {
+                        println!("  ignored .forgeguard/ in .gitignore");
+                    }
                     println!();
                     print!("{}", render_detection(&report.detection));
                 }
@@ -347,6 +366,109 @@ impl From<HookAgentArg> for HookAgent {
     }
 }
 
+/// The five installable agents, in menu order. `AgentArg::All` is offered
+/// separately as the `all` shortcut, so it is not part of this table.
+const AGENT_MENU: &[(&str, AgentTarget)] = &[
+    ("codex", AgentTarget::Codex),
+    ("claude", AgentTarget::Claude),
+    ("cursor", AgentTarget::Cursor),
+    ("opencode", AgentTarget::OpenCode),
+    ("antigravity", AgentTarget::Antigravity),
+];
+
+// ponytail: line-based prompt; add TUI multiselect only if UX complaint.
+fn run_init_wizard() -> Result<(bool, Vec<AgentTarget>, bool)> {
+    println!("ForgeGuard init");
+    let use_global = prompt_choice(
+        "Where do you want to install?",
+        &["This repository (default)", "Global (user directory)"],
+    )? == 1;
+
+    println!("\nWhich agents? (comma-separated numbers, or 'all')");
+    for (index, (name, _)) in AGENT_MENU.iter().enumerate() {
+        println!("  {}) {name}", index + 1);
+    }
+    let agents = parse_agent_selection(&prompt_line("> ")?);
+
+    // The gitignore entry only makes sense for a project checkout.
+    let add_gitignore = !use_global && prompt_yes_no("Add .forgeguard/ to .gitignore?", true)?;
+
+    Ok((use_global, agents, add_gitignore))
+}
+
+/// Map a comma-separated selection (`"1,3"`, `"all"`, empty) onto concrete
+/// agents. Unknown or out-of-range entries are ignored; an empty result falls
+/// back to `All` so a stray Enter never installs nothing.
+fn parse_agent_selection(input: &str) -> Vec<AgentTarget> {
+    let input = input.trim();
+    if input.is_empty() || input.eq_ignore_ascii_case("all") {
+        return vec![AgentTarget::All];
+    }
+    let mut selected: Vec<AgentTarget> = Vec::new();
+    for token in input.split(',') {
+        let token = token.trim();
+        if token.eq_ignore_ascii_case("all") {
+            return vec![AgentTarget::All];
+        }
+        let Ok(number) = token.parse::<usize>() else {
+            continue;
+        };
+        if let Some((_, target)) = AGENT_MENU.get(number.wrapping_sub(1)) {
+            if !selected.contains(target) {
+                selected.push(*target);
+            }
+        }
+    }
+    if selected.is_empty() {
+        vec![AgentTarget::All]
+    } else {
+        selected
+    }
+}
+
+fn prompt_choice(question: &str, options: &[&str]) -> Result<usize> {
+    println!("\n{question}");
+    for (index, option) in options.iter().enumerate() {
+        println!("  {}) {option}", index + 1);
+    }
+    loop {
+        let answer = prompt_line("> ")?;
+        let answer = answer.trim();
+        if answer.is_empty() {
+            return Ok(0);
+        }
+        if let Ok(number) = answer.parse::<usize>() {
+            if (1..=options.len()).contains(&number) {
+                return Ok(number - 1);
+            }
+        }
+        println!("Enter a number between 1 and {}.", options.len());
+    }
+}
+
+fn prompt_yes_no(question: &str, default_yes: bool) -> Result<bool> {
+    let hint = if default_yes { "[Y/n]" } else { "[y/N]" };
+    loop {
+        let answer = prompt_line(&format!("\n{question} {hint} "))?;
+        match answer.trim().to_ascii_lowercase().as_str() {
+            "" => return Ok(default_yes),
+            "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => println!("Please answer y or n."),
+        }
+    }
+}
+
+fn prompt_line(prompt: &str) -> Result<String> {
+    print!("{prompt}");
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .context("failed to read input")?;
+    Ok(line)
+}
+
 fn home_directory() -> Result<PathBuf> {
     env::var_os("HOME")
         .or_else(|| env::var_os("USERPROFILE"))
@@ -360,5 +482,30 @@ fn render_file_changes(written: &[String], skipped: &[String]) {
     }
     for path in skipped {
         println!("  skipped {path} (already exists)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_agent_selection, AgentTarget};
+
+    #[test]
+    fn parses_number_list() {
+        assert_eq!(
+            parse_agent_selection("1,3"),
+            vec![AgentTarget::Codex, AgentTarget::Cursor]
+        );
+    }
+
+    #[test]
+    fn all_and_empty_and_garbage_default_to_all() {
+        assert_eq!(parse_agent_selection("all"), vec![AgentTarget::All]);
+        assert_eq!(parse_agent_selection("  "), vec![AgentTarget::All]);
+        assert_eq!(parse_agent_selection("9,foo"), vec![AgentTarget::All]);
+    }
+
+    #[test]
+    fn dedups_and_skips_out_of_range() {
+        assert_eq!(parse_agent_selection("2,2,7"), vec![AgentTarget::Claude]);
     }
 }

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    io::{IsTerminal, Read, Write},
+    io::{IsTerminal, Read},
     path::PathBuf,
     process::ExitCode,
 };
@@ -376,97 +376,51 @@ const AGENT_MENU: &[(&str, AgentTarget)] = &[
     ("antigravity", AgentTarget::Antigravity),
 ];
 
-// ponytail: line-based prompt; add TUI multiselect only if UX complaint.
-fn run_init_wizard() -> Result<(bool, Vec<AgentTarget>, bool)> {
-    println!("ForgeGuard init");
-    let use_global = prompt_choice(
-        "Where do you want to install?",
-        &["This repository (default)", "Global (user directory)"],
-    )? == 1;
+const SCOPE_PROJECT: &str = "This repository";
+const SCOPE_GLOBAL: &str = "Global (user directory)";
 
-    println!("\nWhich agents? (comma-separated numbers, or 'all')");
-    for (index, (name, _)) in AGENT_MENU.iter().enumerate() {
-        println!("  {}) {name}", index + 1);
-    }
-    let agents = parse_agent_selection(&prompt_line("> ")?);
+fn run_init_wizard() -> Result<(bool, Vec<AgentTarget>, bool)> {
+    let scope = inquire::Select::new(
+        "Where do you want to install?",
+        vec![SCOPE_PROJECT, SCOPE_GLOBAL],
+    )
+    .prompt()
+    .context("init wizard cancelled")?;
+    let use_global = scope == SCOPE_GLOBAL;
+
+    let names: Vec<&str> = AGENT_MENU.iter().map(|(name, _)| *name).collect();
+    let picked = inquire::MultiSelect::new("Which agents?", names)
+        .with_help_message("↑↓ move, space toggle, → all, ← none, enter confirm")
+        .prompt()
+        .context("init wizard cancelled")?;
+    let agents = agents_from_names(&picked);
 
     // The gitignore entry only makes sense for a project checkout.
-    let add_gitignore = !use_global && prompt_yes_no("Add .forgeguard/ to .gitignore?", true)?;
+    let add_gitignore = if use_global {
+        false
+    } else {
+        inquire::Confirm::new("Add .forgeguard/ to .gitignore?")
+            .with_default(true)
+            .prompt()
+            .context("init wizard cancelled")?
+    };
 
     Ok((use_global, agents, add_gitignore))
 }
 
-/// Map a comma-separated selection (`"1,3"`, `"all"`, empty) onto concrete
-/// agents. Unknown or out-of-range entries are ignored; an empty result falls
-/// back to `All` so a stray Enter never installs nothing.
-fn parse_agent_selection(input: &str) -> Vec<AgentTarget> {
-    let input = input.trim();
-    if input.is_empty() || input.eq_ignore_ascii_case("all") {
-        return vec![AgentTarget::All];
-    }
-    let mut selected: Vec<AgentTarget> = Vec::new();
-    for token in input.split(',') {
-        let token = token.trim();
-        if token.eq_ignore_ascii_case("all") {
-            return vec![AgentTarget::All];
-        }
-        let Ok(number) = token.parse::<usize>() else {
-            continue;
-        };
-        if let Some((_, target)) = AGENT_MENU.get(number.wrapping_sub(1)) {
-            if !selected.contains(target) {
-                selected.push(*target);
-            }
-        }
-    }
+/// Map the agent names the user checked onto concrete targets. An empty pick
+/// falls back to `All` so confirming nothing never installs nothing.
+fn agents_from_names(names: &[&str]) -> Vec<AgentTarget> {
+    let selected: Vec<AgentTarget> = AGENT_MENU
+        .iter()
+        .filter(|(name, _)| names.contains(name))
+        .map(|(_, target)| *target)
+        .collect();
     if selected.is_empty() {
         vec![AgentTarget::All]
     } else {
         selected
     }
-}
-
-fn prompt_choice(question: &str, options: &[&str]) -> Result<usize> {
-    println!("\n{question}");
-    for (index, option) in options.iter().enumerate() {
-        println!("  {}) {option}", index + 1);
-    }
-    loop {
-        let answer = prompt_line("> ")?;
-        let answer = answer.trim();
-        if answer.is_empty() {
-            return Ok(0);
-        }
-        if let Ok(number) = answer.parse::<usize>() {
-            if (1..=options.len()).contains(&number) {
-                return Ok(number - 1);
-            }
-        }
-        println!("Enter a number between 1 and {}.", options.len());
-    }
-}
-
-fn prompt_yes_no(question: &str, default_yes: bool) -> Result<bool> {
-    let hint = if default_yes { "[Y/n]" } else { "[y/N]" };
-    loop {
-        let answer = prompt_line(&format!("\n{question} {hint} "))?;
-        match answer.trim().to_ascii_lowercase().as_str() {
-            "" => return Ok(default_yes),
-            "y" | "yes" => return Ok(true),
-            "n" | "no" => return Ok(false),
-            _ => println!("Please answer y or n."),
-        }
-    }
-}
-
-fn prompt_line(prompt: &str) -> Result<String> {
-    print!("{prompt}");
-    std::io::stdout().flush().ok();
-    let mut line = String::new();
-    std::io::stdin()
-        .read_line(&mut line)
-        .context("failed to read input")?;
-    Ok(line)
 }
 
 fn home_directory() -> Result<PathBuf> {
@@ -487,25 +441,26 @@ fn render_file_changes(written: &[String], skipped: &[String]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_agent_selection, AgentTarget};
+    use super::{agents_from_names, AgentTarget};
 
     #[test]
-    fn parses_number_list() {
+    fn maps_checked_names_in_menu_order() {
         assert_eq!(
-            parse_agent_selection("1,3"),
+            agents_from_names(&["cursor", "codex"]),
             vec![AgentTarget::Codex, AgentTarget::Cursor]
         );
     }
 
     #[test]
-    fn all_and_empty_and_garbage_default_to_all() {
-        assert_eq!(parse_agent_selection("all"), vec![AgentTarget::All]);
-        assert_eq!(parse_agent_selection("  "), vec![AgentTarget::All]);
-        assert_eq!(parse_agent_selection("9,foo"), vec![AgentTarget::All]);
+    fn empty_pick_defaults_to_all() {
+        assert_eq!(agents_from_names(&[]), vec![AgentTarget::All]);
     }
 
     #[test]
-    fn dedups_and_skips_out_of_range() {
-        assert_eq!(parse_agent_selection("2,2,7"), vec![AgentTarget::Claude]);
+    fn ignores_unknown_names() {
+        assert_eq!(
+            agents_from_names(&["claude", "bogus"]),
+            vec![AgentTarget::Claude]
+        );
     }
 }

--- a/crates/forgeguard-core/src/hook.rs
+++ b/crates/forgeguard-core/src/hook.rs
@@ -149,7 +149,7 @@ pub fn render_hook_decision(agent: HookAgent, decision: &HookDecision) -> String
 /// `.forgeguard/`. Keep those artifacts out of version control without asking
 /// the user to configure anything: a self-ignoring `.forgeguard/.gitignore`,
 /// plus a `.forgeguard/` entry appended to an existing root `.gitignore`.
-fn ignore_forgeguard_artifacts(root: &Path) -> Result<()> {
+pub fn ignore_forgeguard_artifacts(root: &Path) -> Result<()> {
     let marker = root.join(".forgeguard/.gitignore");
     if !marker.exists() {
         if let Some(parent) = marker.parent() {

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -85,14 +85,14 @@ pub enum AgentTarget {
 #[derive(Debug, Clone)]
 pub struct InitOptions {
     pub force: bool,
-    pub agent: AgentTarget,
+    pub agents: Vec<AgentTarget>,
 }
 
 impl Default for InitOptions {
     fn default() -> Self {
         Self {
             force: false,
-            agent: AgentTarget::All,
+            agents: vec![AgentTarget::All],
         }
     }
 }
@@ -135,7 +135,7 @@ pub fn initialize_global(home: &Path, options: &InitOptions) -> Result<GlobalIni
     install_agents(
         &home,
         InstallScope::Global,
-        options.agent,
+        &options.agents,
         options.force,
         &mut files_written,
         &mut files_skipped,
@@ -177,7 +177,7 @@ pub fn initialize_project(root: &Path, options: &InitOptions) -> Result<InitRepo
     install_agents(
         root,
         InstallScope::Project,
-        options.agent,
+        &options.agents,
         options.force,
         &mut files_written,
         &mut files_skipped,
@@ -193,17 +193,30 @@ pub fn initialize_project(root: &Path, options: &InitOptions) -> Result<InitRepo
 fn install_agents(
     root: &Path,
     scope: InstallScope,
-    target: AgentTarget,
+    requested: &[AgentTarget],
     force: bool,
     written: &mut Vec<String>,
     skipped: &mut Vec<String>,
 ) -> Result<()> {
-    let targets = if target == AgentTarget::All {
-        ALL_AGENT_TARGETS
-    } else {
-        std::slice::from_ref(&target)
+    // Flatten `All` into the concrete list and dedup so `[Claude, All]` never
+    // installs Claude twice.
+    // ponytail: O(n²) contains-check, but n <= 5 agents; a set is not worth it.
+    let mut targets: Vec<AgentTarget> = Vec::new();
+    let push = |target: AgentTarget, targets: &mut Vec<AgentTarget>| {
+        if !targets.contains(&target) {
+            targets.push(target);
+        }
     };
-    for target in targets {
+    for target in requested {
+        if *target == AgentTarget::All {
+            for expanded in ALL_AGENT_TARGETS {
+                push(*expanded, &mut targets);
+            }
+        } else {
+            push(*target, &mut targets);
+        }
+    }
+    for target in &targets {
         match target {
             AgentTarget::Codex => install_codex(root, scope, force, written, skipped)?,
             AgentTarget::Claude => install_claude(root, scope, force, written, skipped)?,

--- a/crates/forgeguard-core/src/lib.rs
+++ b/crates/forgeguard-core/src/lib.rs
@@ -16,7 +16,9 @@ pub use config::{CommandConfig, ForgeGuardConfig, GuardMode};
 pub use detector::{detect_project, ProjectDetection};
 pub use doctor::{run_doctor, DoctorReport};
 pub use gate::{run_gate, GateOptions};
-pub use hook::{evaluate_stop_hook, render_hook_decision, HookAgent, HookDecision};
+pub use hook::{
+    evaluate_stop_hook, ignore_forgeguard_artifacts, render_hook_decision, HookAgent, HookDecision,
+};
 pub use init::{
     initialize_global, initialize_project, AgentTarget, GlobalInitReport, InitOptions, InitReport,
 };

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -16,7 +16,7 @@ fn installs_configuration_for_all_supported_agents() {
         directory.path(),
         &InitOptions {
             force: false,
-            agent: AgentTarget::All,
+            agents: vec![AgentTarget::All],
         },
     )
     .expect("initialize project");
@@ -78,7 +78,7 @@ fn installs_global_skills_without_project_configuration() {
         directory.path(),
         &InitOptions {
             force: false,
-            agent: AgentTarget::All,
+            agents: vec![AgentTarget::All],
         },
     )
     .expect("install global skills");
@@ -128,7 +128,7 @@ fn hook_install_preserves_existing_settings_and_is_idempotent() {
 
     let options = InitOptions {
         force: false,
-        agent: AgentTarget::Claude,
+        agents: vec![AgentTarget::Claude],
     };
     initialize_project(directory.path(), &options).expect("first initialization");
     initialize_project(directory.path(), &options).expect("second initialization");
@@ -163,7 +163,7 @@ fn force_removes_only_legacy_forgeguard_skills() {
         directory.path(),
         &InitOptions {
             force: true,
-            agent: AgentTarget::Codex,
+            agents: vec![AgentTarget::Codex],
         },
     )
     .expect("migrate global skills");
@@ -185,7 +185,7 @@ fn existing_policy_is_preserved_without_force() {
         directory.path(),
         &InitOptions {
             force: false,
-            agent: AgentTarget::Codex,
+            agents: vec![AgentTarget::Codex],
         },
     )
     .expect("initialize project");
@@ -204,7 +204,7 @@ fn opencode_target_uses_shared_standards_without_unrelated_hooks() {
         directory.path(),
         &InitOptions {
             force: false,
-            agent: AgentTarget::OpenCode,
+            agents: vec![AgentTarget::OpenCode],
         },
     )
     .expect("initialize OpenCode");
@@ -230,7 +230,7 @@ fn antigravity_hook_merge_is_idempotent() {
     .expect("write hooks");
     let options = InitOptions {
         force: false,
-        agent: AgentTarget::Antigravity,
+        agents: vec![AgentTarget::Antigravity],
     };
 
     initialize_project(directory.path(), &options).expect("first initialization");
@@ -267,7 +267,7 @@ fn force_unlinks_legacy_symlink_without_removing_target() {
         directory.path(),
         &InitOptions {
             force: true,
-            agent: AgentTarget::Codex,
+            agents: vec![AgentTarget::Codex],
         },
     )
     .expect("migrate global skills");


### PR DESCRIPTION
## Summary
- `forgeguard init` no longer installs all five agents by default when run in a terminal — it launches an interactive wizard to pick scope, agents, and gitignore behavior, so repos stop getting cluttered with unused agent scaffolding.
- Non-terminal runs, `--json`, and explicit flags keep the previous behavior (default: all agents) so scripts and CI are unaffected.

## Changes
- **core (`init.rs`)**: `InitOptions.agent` → `agents: Vec<AgentTarget>`; `install_agents` flattens `All` and dedups.
- **core (`hook.rs`/`lib.rs`)**: expose `ignore_forgeguard_artifacts` so the wizard can reuse the existing gitignore logic.
- **cli (`main.rs`)**: `--agent` is now optional; add an `inquire`-based wizard (arrow-key select, space-toggle multi-select, confirm prompt). Gitignore step only runs for a project checkout.
- **tests**: update `init_test.rs` to the new `agents` field; add unit tests for `agents_from_names`.
- **docs**: flesh out `CLAUDE.md` with the crate layout, commands, and wizard behavior.
- **chore**: add `.github/CODEOWNERS`; symlink `AGENTS.md` to `CLAUDE.md`; ignore local agent scaffolding dirs.

## Test plan
- [x] `cargo test` (core + cli) green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `forgeguard gate --changed --output compact` clean
- [x] non-TTY `init` still installs all agents (backwards compatible)
- [x] manual TTY run: pick a single agent, confirm only that agent's files land

## Evidance
<img width="437" height="159" alt="Screenshot 2026-07-27 at 19 54 43" src="https://github.com/user-attachments/assets/335a1faa-d381-49ba-8dee-a8c185e123ac" />

