### PR TITLE
feat: add configurable ForgeGuard modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ A blocked gate may cause the host agent to use another turn to fix real failures
 - One `forgeguard-engineering` skill with conditional clean-code, algorithm, backend, frontend, mobile, database, AI, and testing references.
 - Static rules for nested iteration, repeated linear lookup, sorting in loops, database I/O in loops, external requests in loops, unbounded fan-out, `SELECT *`, and potential duplicated blocks.
 - Automatic formatter, linter, type-check, test, and build command discovery.
-- `lite`, `guard`, and `strict` enforcement modes.
+- `default`, `lite`, and `strict` operating modes with project and global persistence.
+- Interactive mode selection during `forgeguard init` and via `forgeguard mode`.
 - Human-readable and JSON reports.
 
 ## Install
@@ -171,7 +172,7 @@ Example:
 
 ```toml
 version = 1
-mode = "guard"
+mode = "default"
 
 [project]
 name = "example-service"
@@ -199,9 +200,36 @@ timeout_seconds = 600
 
 ### Modes
 
-- `lite`: reports findings but blocks only failed required commands.
-- `guard`: blocks error-level deterministic findings and failed required commands.
-- `strict`: also blocks warning-level findings until fixed or explicitly configured.
+ForgeGuard supports three operating modes:
+
+- `default`: token-friendly default for new installs. Static findings are reported, but only failed required commands block.
+- `lite`: report-only mode for baselining or cleanup work. Static findings do not block.
+- `strict`: strong guard mode. Failed required commands and error-level deterministic findings block.
+
+Older configs with `mode = "guard"` still load as `strict` for compatibility.
+
+Set project mode:
+
+```bash
+forgeguard mode default
+forgeguard mode lite
+forgeguard mode strict
+```
+
+Set user-level/global mode:
+
+```bash
+forgeguard mode strict --global
+```
+
+Inspect mode as JSON:
+
+```bash
+forgeguard mode --json
+forgeguard mode --global --json
+```
+
+When run in a terminal without an explicit mode, `forgeguard mode` opens the same interactive mode picker used by `forgeguard init`. Non-TTY calls and `--json` never prompt, so scripts and CI do not hang.
 
 ## Commands
 
@@ -210,6 +238,7 @@ timeout_seconds = 600
 | `forgeguard init` | Install project configuration and agent skills. Use `--global` for user-level skills. |
 | `forgeguard detect` | Detect languages, frameworks, database tools, tests, and commands. |
 | `forgeguard doctor` | Verify configuration, Git, and required local tools. |
+| `forgeguard mode` | Check or change project/global operating mode. |
 | `forgeguard gate` | Run static rules and configured quality commands. |
 | `forgeguard review` | Scan Git-changed files without running commands. |
 | `forgeguard hook stop` | Internal token-efficient lifecycle adapter for supported agents. |

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -1,11 +1,11 @@
 use std::{
     env,
-    io::{IsTerminal, Read},
-    path::PathBuf,
+    io::{self, IsTerminal, Read, Write},
+    path::{Path, PathBuf},
     process::ExitCode,
 };
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use forgeguard_core::{
     config::{ForgeGuardConfig, CONFIG_FILE},
@@ -13,7 +13,7 @@ use forgeguard_core::{
     git::changed_files,
     initialize_global, initialize_project, render_hook_decision,
     report::{render_detection, render_doctor, render_gate, render_gate_compact},
-    run_doctor, run_gate, AgentTarget, GateOptions, GateReport, GateStatus, HookAgent,
+    run_doctor, run_gate, AgentTarget, GateOptions, GateReport, GateStatus, GuardMode, HookAgent,
     HookDecision, InitOptions,
 };
 
@@ -48,6 +48,15 @@ enum Commands {
     },
     /// Detect languages, frameworks, database tools, tests, and quality commands.
     Detect {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Check or change ForgeGuard mode.
+    Mode {
+        #[arg(value_enum)]
+        mode: Option<ModeArg>,
+        #[arg(long)]
+        global: bool,
         #[arg(long)]
         json: bool,
     },
@@ -99,6 +108,13 @@ enum OutputArg {
     Full,
     Compact,
     Quiet,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ModeArg {
+    Default,
+    Lite,
+    Strict,
 }
 
 #[derive(Debug, Subcommand)]
@@ -164,6 +180,9 @@ fn execute() -> Result<ExitCode> {
                         report.home.display()
                     );
                     render_file_changes(&report.files_written, &report.files_skipped);
+                    if io::stdin().is_terminal() {
+                        configure_mode_interactive(&home, true)?;
+                    }
                 }
             } else {
                 let report = initialize_project(&root, &options)?;
@@ -180,6 +199,9 @@ fn execute() -> Result<ExitCode> {
                     }
                     println!();
                     print!("{}", render_detection(&report.detection));
+                    if io::stdin().is_terminal() {
+                        configure_mode_interactive(&root, false)?;
+                    }
                 }
             }
             if !json {
@@ -196,6 +218,7 @@ fn execute() -> Result<ExitCode> {
             }
             Ok(ExitCode::SUCCESS)
         }
+        Commands::Mode { mode, global, json } => execute_mode(&root, mode, global, json),
         Commands::Doctor { json } => {
             let config = if root.join(CONFIG_FILE).exists() {
                 Some(ForgeGuardConfig::load(&root)?)
@@ -273,9 +296,111 @@ fn execute() -> Result<ExitCode> {
     }
 }
 
-fn execute_stop_hook(root: &std::path::Path, agent: HookAgent) -> Result<ExitCode> {
+fn execute_mode(root: &Path, mode: Option<ModeArg>, global: bool, json: bool) -> Result<ExitCode> {
+    let target = if global {
+        home_directory()?
+    } else {
+        root.to_path_buf()
+    };
+    let mut config = load_or_create_config(&target, global)?;
+    let selected = match mode {
+        Some(mode) => mode.into(),
+        None if io::stdin().is_terminal() && !json => prompt_for_mode(config.mode)?,
+        None => config.mode,
+    };
+    config.mode = selected;
+    save_config(&target, global, &config)?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "scope": if global { "global" } else { "project" },
+                "mode": config.mode.as_str(),
+            })
+        );
+    } else {
+        println!(
+            "ForgeGuard {} mode set to {}.",
+            if global { "global" } else { "project" },
+            config.mode.as_str()
+        );
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn configure_mode_interactive(target: &Path, global: bool) -> Result<()> {
+    let mut config = load_or_create_config(target, global)?;
+    println!();
+    let mode = prompt_for_mode(config.mode)?;
+    config.mode = mode;
+    save_config(target, global, &config)?;
+    println!(
+        "ForgeGuard {} mode set to {}.",
+        if global { "global" } else { "project" },
+        config.mode.as_str()
+    );
+    Ok(())
+}
+
+fn prompt_for_mode(default: GuardMode) -> Result<GuardMode> {
+    println!("ForgeGuard mode");
+    println!("  1) default - token-friendly; report static findings, block only failed required commands");
+    println!("  2) lite    - report-only; never blocks");
+    println!("  3) strict  - block failed required commands and error-level findings");
+    print!("Choose mode [{}]: ", default.as_str());
+    io::stdout().flush()?;
+
     let mut input = String::new();
-    std::io::stdin()
+    io::stdin().read_line(&mut input)?;
+    parse_mode(input.trim()).map(|mode| mode.unwrap_or(default))
+}
+
+fn parse_mode(value: &str) -> Result<Option<GuardMode>> {
+    let mode = match value.trim().to_ascii_lowercase().as_str() {
+        "" => return Ok(None),
+        "1" | "default" => GuardMode::Default,
+        "2" | "lite" => GuardMode::Lite,
+        "3" | "strict" | "guard" => GuardMode::Strict,
+        other => bail!("unknown mode `{other}`; expected default, lite, or strict"),
+    };
+    Ok(Some(mode))
+}
+
+fn load_or_create_config(target: &Path, global: bool) -> Result<ForgeGuardConfig> {
+    if global {
+        return match ForgeGuardConfig::load_global(target) {
+            Ok(config) => Ok(config),
+            Err(_) => Ok(ForgeGuardConfig::new("global", Vec::new())),
+        };
+    }
+    match ForgeGuardConfig::load(target) {
+        Ok(config) => Ok(config),
+        Err(_) => {
+            let detection = detect_project(target)?;
+            let project_name = target
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("project");
+            Ok(ForgeGuardConfig::new(
+                project_name,
+                detection.suggested_commands,
+            ))
+        }
+    }
+}
+
+fn save_config(target: &Path, global: bool, config: &ForgeGuardConfig) -> Result<()> {
+    if global {
+        config.save_global(target)
+    } else {
+        config.save(target)
+    }
+}
+
+fn execute_stop_hook(root: &Path, agent: HookAgent) -> Result<ExitCode> {
+    let mut input = String::new();
+    io::stdin()
         .read_to_string(&mut input)
         .context("failed to read hook input")?;
     let home = home_directory().ok();
@@ -307,7 +432,7 @@ fn execute_stop_hook(root: &std::path::Path, agent: HookAgent) -> Result<ExitCod
     Ok(ExitCode::SUCCESS)
 }
 
-fn append_update_notice(reason: String, home: Option<&std::path::Path>) -> String {
+fn append_update_notice(reason: String, home: Option<&Path>) -> String {
     match home.and_then(forgeguard_core::update::cached_notice) {
         Some(notice) => format!("{reason}\n\n{notice}"),
         None => reason,
@@ -351,6 +476,16 @@ impl From<AgentArg> for AgentTarget {
             AgentArg::OpenCode => Self::OpenCode,
             AgentArg::Antigravity => Self::Antigravity,
             AgentArg::All => Self::All,
+        }
+    }
+}
+
+impl From<ModeArg> for GuardMode {
+    fn from(value: ModeArg) -> Self {
+        match value {
+            ModeArg::Default => Self::Default,
+            ModeArg::Lite => Self::Lite,
+            ModeArg::Strict => Self::Strict,
         }
     }
 }

--- a/crates/forgeguard-core/src/config.rs
+++ b/crates/forgeguard-core/src/config.rs
@@ -5,21 +5,26 @@ use serde::{Deserialize, Serialize};
 
 pub const CONFIG_DIR: &str = ".forgeguard";
 pub const CONFIG_FILE: &str = ".forgeguard/config.toml";
+pub const GLOBAL_CONFIG_FILE: &str = ".forgeguard/config.toml";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum GuardMode {
-    Lite,
+    /// Token-friendly default: report static findings but block only failed required commands.
     #[default]
-    Guard,
+    Default,
+    /// Report-only mode: never blocks; useful for baselining and cleanup lists.
+    Lite,
+    /// Full guard mode: blocks failed required commands and error-level deterministic findings.
+    #[serde(alias = "guard")]
     Strict,
 }
 
 impl GuardMode {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::Default => "default",
             Self::Lite => "lite",
-            Self::Guard => "guard",
             Self::Strict => "strict",
         }
     }
@@ -85,7 +90,7 @@ impl ForgeGuardConfig {
     pub fn new(project_name: impl Into<String>, commands: Vec<CommandConfig>) -> Self {
         Self {
             version: default_config_version(),
-            mode: GuardMode::Guard,
+            mode: GuardMode::Default,
             project: ProjectConfig {
                 name: project_name.into(),
             },
@@ -95,19 +100,35 @@ impl ForgeGuardConfig {
     }
 
     pub fn load(root: &Path) -> Result<Self> {
-        let path = root.join(CONFIG_FILE);
-        let source = fs::read_to_string(&path)
+        Self::load_from_path(&root.join(CONFIG_FILE))
+    }
+
+    pub fn save(&self, root: &Path) -> Result<()> {
+        self.save_to_path(&root.join(CONFIG_FILE))
+    }
+
+    pub fn load_global(home: &Path) -> Result<Self> {
+        Self::load_from_path(&home.join(GLOBAL_CONFIG_FILE))
+    }
+
+    pub fn save_global(&self, home: &Path) -> Result<()> {
+        self.save_to_path(&home.join(GLOBAL_CONFIG_FILE))
+    }
+
+    fn load_from_path(path: &Path) -> Result<Self> {
+        let source = fs::read_to_string(path)
             .with_context(|| format!("failed to read {}", path.display()))?;
         toml::from_str(&source).with_context(|| format!("failed to parse {}", path.display()))
     }
 
-    pub fn save(&self, root: &Path) -> Result<()> {
-        let directory = root.join(CONFIG_DIR);
-        fs::create_dir_all(&directory)
+    fn save_to_path(&self, path: &Path) -> Result<()> {
+        let directory = path
+            .parent()
+            .context("ForgeGuard config path has no parent")?;
+        fs::create_dir_all(directory)
             .with_context(|| format!("failed to create {}", directory.display()))?;
         let output = toml::to_string_pretty(self).context("failed to serialize configuration")?;
-        let path = root.join(CONFIG_FILE);
-        fs::write(&path, output).with_context(|| format!("failed to write {}", path.display()))
+        fs::write(path, output).with_context(|| format!("failed to write {}", path.display()))
     }
 }
 

--- a/crates/forgeguard-core/src/gate.rs
+++ b/crates/forgeguard-core/src/gate.rs
@@ -52,10 +52,7 @@ pub fn run_gate(
     let checks_failed = checks.iter().filter(|check| !check.success).count();
     let required_check_failed = checks.iter().any(|check| check.required && !check.success);
 
-    let status = if required_check_failed
-        || matches!(config.mode, GuardMode::Guard | GuardMode::Strict) && errors > 0
-        || config.mode == GuardMode::Strict && warnings > 0
-    {
+    let status = if required_check_failed || config.mode == GuardMode::Strict && errors > 0 {
         GateStatus::Blocked
     } else if errors + warnings + info + checks_failed > 0 {
         GateStatus::Warning

--- a/crates/forgeguard-core/tests/config_test.rs
+++ b/crates/forgeguard-core/tests/config_test.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use forgeguard_core::{CommandConfig, ForgeGuardConfig, GuardMode};
 use tempfile::tempdir;
 
@@ -20,4 +22,50 @@ fn configuration_round_trips_through_toml() {
     let loaded = ForgeGuardConfig::load(directory.path()).expect("load config");
 
     assert_eq!(loaded, config);
+}
+
+#[test]
+fn new_configuration_defaults_to_default_mode() {
+    let config = ForgeGuardConfig::new("example", Vec::new());
+    assert_eq!(config.mode, GuardMode::Default);
+}
+
+#[test]
+fn legacy_guard_mode_loads_as_strict() {
+    let directory = tempdir().expect("temp directory");
+    fs::create_dir_all(directory.path().join(".forgeguard")).expect("create config dir");
+    fs::write(
+        directory.path().join(".forgeguard/config.toml"),
+        r#"version = 1
+mode = "guard"
+
+[project]
+name = "legacy"
+
+[scan]
+enabled = true
+max_file_bytes = 1000000
+include_tests = false
+extra_excludes = []
+duplicate_block_lines = 6
+"#,
+    )
+    .expect("write legacy config");
+
+    let config = ForgeGuardConfig::load(directory.path()).expect("load legacy config");
+    assert_eq!(config.mode, GuardMode::Strict);
+}
+
+#[test]
+fn global_configuration_round_trips_through_toml() {
+    let directory = tempdir().expect("temp directory");
+    let config = ForgeGuardConfig::new("global", Vec::new());
+
+    config
+        .save_global(directory.path())
+        .expect("save global config");
+    let loaded = ForgeGuardConfig::load_global(directory.path()).expect("load global config");
+
+    assert_eq!(loaded, config);
+    assert!(directory.path().join(".forgeguard/config.toml").exists());
 }

--- a/crates/forgeguard-core/tests/gate_test.rs
+++ b/crates/forgeguard-core/tests/gate_test.rs
@@ -4,7 +4,7 @@ use forgeguard_core::{run_gate, ForgeGuardConfig, GateOptions, GateStatus, Guard
 use tempfile::tempdir;
 
 #[test]
-fn guard_mode_blocks_error_level_findings() {
+fn default_mode_reports_static_findings_without_blocking() {
     let directory = tempdir().expect("temp directory");
     fs::write(
         directory.path().join("repository.ts"),
@@ -16,6 +16,34 @@ for (const user of users) {
     )
     .expect("write source");
     let config = ForgeGuardConfig::new("sample", Vec::new());
+
+    let report = run_gate(
+        directory.path(),
+        &config,
+        &GateOptions {
+            skip_commands: true,
+            paths: None,
+        },
+    )
+    .expect("run gate");
+
+    assert_eq!(report.status, GateStatus::Warning);
+}
+
+#[test]
+fn strict_mode_blocks_error_level_findings() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("repository.ts"),
+        r#"
+for (const user of users) {
+  await db.query("SELECT id FROM profiles WHERE user_id = ?", [user.id]);
+}
+"#,
+    )
+    .expect("write source");
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = GuardMode::Strict;
 
     let report = run_gate(
         directory.path(),

--- a/crates/forgeguard-core/tests/hook_test.rs
+++ b/crates/forgeguard-core/tests/hook_test.rs
@@ -9,9 +9,9 @@ use tempfile::tempdir;
 fn blocked_hook_is_compact_cached_and_loop_safe() {
     let directory = tempdir().expect("temp directory");
     git_init(directory.path());
-    ForgeGuardConfig::new("sample", Vec::new())
-        .save(directory.path())
-        .expect("save config");
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = forgeguard_core::GuardMode::Strict;
+    config.save(directory.path()).expect("save config");
     for index in 0..40 {
         fs::write(
             directory.path().join(format!("repository-{index}.ts")),
@@ -114,7 +114,7 @@ fn agent_protocols_are_silent_or_structured() {
 }
 
 #[test]
-fn auto_gate_runs_without_config_and_ignores_artifacts() {
+fn auto_gate_reports_without_blocking_without_config_and_ignores_artifacts() {
     let directory = tempdir().expect("temp directory");
     git_init(directory.path());
     // A pre-existing root .gitignore must be appended to, not clobbered.
@@ -130,7 +130,7 @@ fn auto_gate_runs_without_config_and_ignores_artifacts() {
         directory.path().display()
     );
     let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("evaluate hook");
-    assert!(matches!(decision, HookDecision::Block(_)));
+    assert_eq!(decision, HookDecision::Pass);
 
     // No manual setup, yet artifacts are kept out of version control.
     let marker = fs::read_to_string(directory.path().join(".forgeguard/.gitignore"))


### PR DESCRIPTION
## Summary

This PR adds configurable ForgeGuard operating modes and wires them through config persistence, gate behavior, hook behavior, and the CLI.

New modes:

- `default` — token-friendly default for new installs. Static findings are reported as warnings, but only failed required commands block.
- `lite` — report-only / baseline mode. Static findings do not block.
- `strict` — strong guard behavior. Failed required commands and error-level deterministic findings block.

The previous serialized `mode = "guard"` value remains supported as a backwards-compatible alias for `strict`.

## What changed

### Core config

- Replaced the old `lite` / `guard` / `strict` enum shape with `default` / `lite` / `strict`.
- Made `default` the new mode produced by `ForgeGuardConfig::new(...)`.
- Added `GuardMode::as_str()` for user-facing output.
- Added global config load/save helpers that use the same `.forgeguard/config.toml` path under the user home directory.
- Added tests for:
  - default mode on new configs,
  - round-trip config serialization,
  - legacy `guard` deserialization as `strict`,
  - global config round-trip persistence.

### Gate and hook behavior

- Required command failures still block in all modes.
- Error-level static findings block only in `strict` mode.
- `default` and `lite` report static findings without blocking the agent loop.
- Hook tests were updated so auto-gate without config now passes instead of injecting non-blocking feedback, keeping hook output token-friendly.

### CLI mode management

Added:

```bash
forgeguard mode
forgeguard mode default
forgeguard mode lite
forgeguard mode strict
forgeguard mode --global
forgeguard mode --json
```

Behavior:

- With a TTY and no explicit mode, `forgeguard mode` opens a mode-selection prompt.
- In non-interactive or JSON mode, it reports the current mode without prompting.
- Project mode writes to the project `.forgeguard/config.toml`.
- Global mode writes under the user home `.forgeguard/config.toml`.
- Missing config is created on demand so users can set a mode before a full init if needed.

### Init flow

- `forgeguard init` now continues into the same mode-selection flow after project/global installation when running interactively.
- `forgeguard init --json`, piped/non-TTY calls, and explicit scripted flows remain non-interactive so CI and automation do not hang.
- This integrates with the existing interactive init wizard from `main`.

### Documentation

- Updated the README capability list, configuration example, mode reference, and command table to document `default`, `lite`, `strict`, `forgeguard mode`, global mode, JSON inspection, and non-interactive prompt behavior.

## Validation

Ran after rebasing onto latest `origin/main`:

```bash
cargo fmt --check
cargo test --workspace
./target/debug/forgeguard gate --changed --output compact
```

Manual CLI checks:

```bash
forgeguard init --agent opencode --json
forgeguard mode lite
forgeguard mode --json
forgeguard mode strict --global
forgeguard mode --global --json
```

Also verified an interactive init flow through a pseudo-TTY where selecting option `2` writes:

```toml
mode = "lite"
```

## Notes

This intentionally does not add a new hook protocol decision for non-blocking feedback. The hook path remains pass/block only, which avoids adding token noise for `default` and `lite` findings. Full details are still available through explicit `forgeguard gate` / `forgeguard review` runs and local reports.

