### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]


### PR DESCRIPTION
## Summary

Prepare ForgeGuard `v0.5.0` by bumping the workspace package version from `0.4.0` to `0.5.0`.

## Why

The release workflow verifies that the pushed tag matches the package version in `Cargo.toml`:

```bash
test "${GITHUB_REF_NAME#v}" = "$package_version"
```

So `v0.5.0` must only be tagged after the package version on `main` is `0.5.0`.

## Changes

- Update `[workspace.package] version` in `Cargo.toml` to `0.5.0`.
- Regenerate `Cargo.lock` so the internal `forgeguard` and `forgeguard-core` packages resolve to `0.5.0`.

## Validation

Ran locally:

```bash
cargo check --workspace
cargo fmt --check
cargo test --workspace
```

After this PR is merged, the next release step is:

```bash
git checkout main
git pull --ff-only origin main
git tag v0.5.0
git push origin v0.5.0
```
