### PR TITLE
feat: add finding baselines and agent directory ignores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A blocked gate may cause the host agent to use another turn to fix real failures
 - Static rules for nested iteration, repeated linear lookup, sorting in loops, database I/O in loops, external requests in loops, unbounded fan-out, `SELECT *`, and potential duplicated blocks.
 - Automatic formatter, linter, type-check, test, and build command discovery.
 - `default`, `lite`, and `strict` operating modes with project and global persistence.
+- Committed finding baselines for adopting strict gates without accepting new debt.
 - Interactive mode selection during `forgeguard init` and via `forgeguard mode`.
 - Human-readable and JSON reports.
 
@@ -128,11 +129,26 @@ Produce bounded agent-facing output:
 forgeguard gate --changed --output compact
 ```
 
+Record current static findings, then report only new findings:
+
+```bash
+forgeguard baseline create
+git add .forgeguard/baseline.json
+forgeguard gate
+```
+
+Replace a stale baseline after reviewing current findings:
+
+```bash
+forgeguard baseline create --force
+```
+
 ## Generated project structure
 
 ```text
 your-project/
 ├── .forgeguard/config.toml
+├── .forgeguard/baseline.json  # after `forgeguard baseline create`
 ├── .forgeguard/.gitignore
 ├── AGENTS.md
 ├── CLAUDE.md
@@ -151,6 +167,10 @@ your-project/
 ```
 
 Existing policy and skill files are not overwritten unless `--force` is supplied. Hook installation merges one ForgeGuard entry into existing JSON and preserves unrelated settings. Global installation writes ForgeGuard-owned skills, compact policies, and hook entries for selected agents. `--force` also removes obsolete ForgeGuard-owned role-skill directories without touching unrelated skills.
+
+When a project `.gitignore` already exists, `forgeguard init` appends the generated directories for
+the selected agents (`.codex/`, `.claude/`, `.cursor/`, and/or `.agents/`). It preserves existing
+patterns, avoids duplicate entries, and does not create a root `.gitignore`.
 
 ## Agent support
 
@@ -241,6 +261,7 @@ When run in a terminal without an explicit mode, `forgeguard mode` opens the sam
 | `forgeguard mode` | Check or change project/global operating mode. |
 | `forgeguard gate` | Run static rules and configured quality commands. |
 | `forgeguard review` | Scan Git-changed files without running commands. |
+| `forgeguard baseline create` | Record current static findings so gates report only new findings. |
 | `forgeguard hook stop` | Internal token-efficient lifecycle adapter for supported agents. |
 
 ## Agent contract

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -9,12 +9,12 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use forgeguard_core::{
     config::{ForgeGuardConfig, CONFIG_FILE},
-    detect_project, evaluate_stop_hook,
+    create_baseline, detect_project, evaluate_stop_hook,
     git::changed_files,
     initialize_global, initialize_project, render_hook_decision,
     report::{render_detection, render_doctor, render_gate, render_gate_compact},
     run_doctor, run_gate, AgentTarget, GateOptions, GateReport, GateStatus, GuardMode, HookAgent,
-    HookDecision, InitOptions,
+    HookDecision, InitOptions, BASELINE_FILE,
 };
 
 #[derive(Debug, Parser)]
@@ -83,6 +83,11 @@ enum Commands {
         #[arg(long, value_enum, default_value = "full", conflicts_with = "json")]
         output: OutputArg,
     },
+    /// Record current static findings so gates report only new findings.
+    Baseline {
+        #[command(subcommand)]
+        command: BaselineCommands,
+    },
     /// Run lifecycle adapters used by supported AI coding agents.
     Hook {
         #[command(subcommand)]
@@ -123,6 +128,17 @@ enum HookCommands {
     Stop {
         #[arg(long, value_enum)]
         agent: HookAgentArg,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum BaselineCommands {
+    /// Write current static findings to .forgeguard/baseline.json.
+    Create {
+        #[arg(long)]
+        force: bool,
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -278,6 +294,29 @@ fn execute() -> Result<ExitCode> {
             )?;
             render_gate_output(&report, json, output)?;
             Ok(exit_code_for_status(report.status))
+        }
+        Commands::Baseline {
+            command: BaselineCommands::Create { force, json },
+        } => {
+            let config = ForgeGuardConfig::load(&root).context(
+                "ForgeGuard is not initialized; run `forgeguard init` in the repository first",
+            )?;
+            let baseline = create_baseline(&root, &config.scan, force)?;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "path": BASELINE_FILE,
+                        "findings": baseline.total_findings(),
+                    })
+                );
+            } else {
+                println!(
+                    "ForgeGuard baseline created: {} finding(s) at {BASELINE_FILE}",
+                    baseline.total_findings()
+                );
+            }
+            Ok(ExitCode::SUCCESS)
         }
         Commands::Hook {
             command: HookCommands::Stop { agent },
@@ -576,7 +615,9 @@ fn render_file_changes(written: &[String], skipped: &[String]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{agents_from_names, AgentTarget};
+    use clap::Parser;
+
+    use super::{agents_from_names, AgentTarget, BaselineCommands, Cli, Commands};
 
     #[test]
     fn maps_checked_names_in_menu_order() {
@@ -597,5 +638,21 @@ mod tests {
             agents_from_names(&["claude", "bogus"]),
             vec![AgentTarget::Claude]
         );
+    }
+
+    #[test]
+    fn parses_forced_json_baseline_creation() {
+        let cli = Cli::try_parse_from(["forgeguard", "baseline", "create", "--force", "--json"])
+            .expect("parse baseline command");
+
+        assert!(matches!(
+            cli.command,
+            Commands::Baseline {
+                command: BaselineCommands::Create {
+                    force: true,
+                    json: true
+                }
+            }
+        ));
     }
 }

--- a/crates/forgeguard-core/src/baseline.rs
+++ b/crates/forgeguard-core/src/baseline.rs
@@ -1,0 +1,160 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+    path::Path,
+};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::ScanConfig,
+    model::{Finding, Severity},
+    scanner::{scan_project, ScanOptions},
+};
+
+pub const BASELINE_FILE: &str = ".forgeguard/baseline.json";
+const BASELINE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Baseline {
+    pub version: u32,
+    pub findings: Vec<BaselineEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BaselineEntry {
+    pub rule_id: String,
+    pub severity: Severity,
+    pub path: String,
+    pub evidence: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct BaselineKey {
+    rule_id: String,
+    severity: Severity,
+    path: String,
+    evidence: String,
+}
+
+impl Baseline {
+    pub fn from_findings(findings: &[Finding]) -> Self {
+        let mut counts = BTreeMap::new();
+        for finding in findings {
+            *counts.entry(key_for_finding(finding)).or_insert(0) += 1;
+        }
+        Self {
+            version: BASELINE_VERSION,
+            findings: counts
+                .into_iter()
+                .map(|(key, count)| BaselineEntry {
+                    rule_id: key.rule_id,
+                    severity: key.severity,
+                    path: key.path,
+                    evidence: key.evidence,
+                    count,
+                })
+                .collect(),
+        }
+    }
+
+    pub fn load(root: &Path) -> Result<Option<Self>> {
+        let path = root.join(BASELINE_FILE);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let source = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let baseline: Self = serde_json::from_str(&source)
+            .with_context(|| format!("failed to parse {}", path.display()))?;
+        if baseline.version != BASELINE_VERSION {
+            bail!(
+                "unsupported baseline version {} in {}; expected {}",
+                baseline.version,
+                path.display(),
+                BASELINE_VERSION
+            );
+        }
+        if baseline.findings.iter().any(|entry| entry.count == 0) {
+            bail!("invalid zero-count finding in {}", path.display());
+        }
+        Ok(Some(baseline))
+    }
+
+    pub fn total_findings(&self) -> usize {
+        self.findings
+            .iter()
+            .fold(0, |total, entry| total.saturating_add(entry.count))
+    }
+
+    pub fn filter(&self, findings: &mut Vec<Finding>) -> usize {
+        let mut remaining = HashMap::new();
+        for entry in &self.findings {
+            let count = remaining.entry(key_for_entry(entry)).or_insert(0usize);
+            *count = count.saturating_add(entry.count);
+        }
+
+        let mut filtered = 0;
+        findings.retain(|finding| {
+            let Some(count) = remaining.get_mut(&key_for_finding(finding)) else {
+                return true;
+            };
+            if *count == 0 {
+                return true;
+            }
+            *count -= 1;
+            filtered += 1;
+            false
+        });
+        filtered
+    }
+}
+
+pub fn create_baseline(root: &Path, config: &ScanConfig, force: bool) -> Result<Baseline> {
+    let path = root.join(BASELINE_FILE);
+    if path.exists() && !force {
+        bail!(
+            "{} already exists; use `forgeguard baseline create --force` to replace it",
+            path.display()
+        );
+    }
+
+    let findings = scan_project(root, config, &ScanOptions::default())?;
+    let baseline = Baseline::from_findings(&findings);
+    let parent = path
+        .parent()
+        .context("ForgeGuard baseline path has no parent")?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    let mut output =
+        serde_json::to_string_pretty(&baseline).context("failed to serialize baseline")?;
+    output.push('\n');
+    fs::write(&path, output).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(baseline)
+}
+
+fn key_for_finding(finding: &Finding) -> BaselineKey {
+    BaselineKey {
+        rule_id: finding.rule_id.clone(),
+        severity: finding.severity,
+        path: portable_path(&finding.path),
+        evidence: finding.evidence.clone(),
+    }
+}
+
+fn key_for_entry(entry: &BaselineEntry) -> BaselineKey {
+    BaselineKey {
+        rule_id: entry.rule_id.clone(),
+        severity: entry.severity,
+        path: entry.path.clone(),
+        evidence: entry.evidence.clone(),
+    }
+}
+
+fn portable_path(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}

--- a/crates/forgeguard-core/src/gate.rs
+++ b/crates/forgeguard-core/src/gate.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 
 use crate::{
+    baseline::Baseline,
     config::{ForgeGuardConfig, GuardMode},
     model::{GateReport, GateStatus, GateSummary, Severity},
     runner::run_checks,
@@ -30,6 +31,10 @@ pub fn run_gate(
     findings.dedup_by(|left, right| {
         left.rule_id == right.rule_id && left.path == right.path && left.line == right.line
     });
+    let findings_baselined = match Baseline::load(root)? {
+        Some(baseline) => baseline.filter(&mut findings),
+        None => 0,
+    };
     let checks = if options.skip_commands {
         Vec::new()
     } else {
@@ -68,6 +73,7 @@ pub fn run_gate(
             errors,
             warnings,
             info,
+            findings_baselined,
             checks_passed,
             checks_failed,
         },

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -182,6 +182,7 @@ pub fn initialize_project(root: &Path, options: &InitOptions) -> Result<InitRepo
         &mut files_written,
         &mut files_skipped,
     )?;
+    ignore_project_agent_directories(root, &options.agents, &mut files_written)?;
 
     Ok(InitReport {
         detection,
@@ -198,8 +199,20 @@ fn install_agents(
     written: &mut Vec<String>,
     skipped: &mut Vec<String>,
 ) -> Result<()> {
-    // Flatten `All` into the concrete list and dedup so `[Claude, All]` never
-    // installs Claude twice.
+    for target in expand_agent_targets(requested) {
+        match target {
+            AgentTarget::Codex => install_codex(root, scope, force, written, skipped)?,
+            AgentTarget::Claude => install_claude(root, scope, force, written, skipped)?,
+            AgentTarget::Cursor => install_cursor(root, scope, force, written, skipped)?,
+            AgentTarget::OpenCode => install_opencode(root, scope, force, written, skipped)?,
+            AgentTarget::Antigravity => install_antigravity(root, scope, force, written, skipped)?,
+            AgentTarget::All => unreachable!("all is expanded before installation"),
+        }
+    }
+    Ok(())
+}
+
+fn expand_agent_targets(requested: &[AgentTarget]) -> Vec<AgentTarget> {
     // ponytail: O(n²) contains-check, but n <= 5 agents; a set is not worth it.
     let mut targets: Vec<AgentTarget> = Vec::new();
     let push = |target: AgentTarget, targets: &mut Vec<AgentTarget>| {
@@ -209,6 +222,7 @@ fn install_agents(
     };
     for target in requested {
         if *target == AgentTarget::All {
+            // forgeguard: allow FG-ALG-001 -- at most five requested agents expand across five targets
             for expanded in ALL_AGENT_TARGETS {
                 push(*expanded, &mut targets);
             }
@@ -216,15 +230,68 @@ fn install_agents(
             push(*target, &mut targets);
         }
     }
-    for target in &targets {
-        match target {
-            AgentTarget::Codex => install_codex(root, scope, force, written, skipped)?,
-            AgentTarget::Claude => install_claude(root, scope, force, written, skipped)?,
-            AgentTarget::Cursor => install_cursor(root, scope, force, written, skipped)?,
-            AgentTarget::OpenCode => install_opencode(root, scope, force, written, skipped)?,
-            AgentTarget::Antigravity => install_antigravity(root, scope, force, written, skipped)?,
-            AgentTarget::All => unreachable!("all is expanded before installation"),
+    targets
+}
+
+fn ignore_project_agent_directories(
+    root: &Path,
+    requested: &[AgentTarget],
+    written: &mut Vec<String>,
+) -> Result<()> {
+    let path = root.join(".gitignore");
+    if !path.is_file() {
+        return Ok(());
+    }
+
+    let targets = expand_agent_targets(requested);
+    let mut entries = Vec::new();
+    if targets.contains(&AgentTarget::Codex) {
+        entries.push(".codex/");
+    }
+    if targets.contains(&AgentTarget::Claude) {
+        entries.push(".claude/");
+    }
+    if targets.contains(&AgentTarget::Cursor) {
+        entries.push(".cursor/");
+    }
+    if targets.iter().any(|target| {
+        matches!(
+            target,
+            AgentTarget::Codex
+                | AgentTarget::Cursor
+                | AgentTarget::OpenCode
+                | AgentTarget::Antigravity
+        )
+    }) {
+        entries.push(".agents/");
+    }
+
+    let mut content =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let newline = if content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let mut changed = false;
+    for entry in entries {
+        let expected = entry.trim_end_matches('/');
+        if content
+            .lines()
+            .any(|line| line.trim().trim_matches('/') == expected)
+        {
+            continue;
         }
+        if !content.is_empty() && !content.ends_with('\n') {
+            content.push_str(newline);
+        }
+        content.push_str(entry);
+        content.push_str(newline);
+        changed = true;
+    }
+    if changed {
+        fs::write(&path, content).with_context(|| format!("failed to write {}", path.display()))?;
+        record_path(root, &path, written);
     }
     Ok(())
 }

--- a/crates/forgeguard-core/src/lib.rs
+++ b/crates/forgeguard-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod baseline;
 pub mod config;
 pub mod detector;
 pub mod doctor;
@@ -12,6 +13,7 @@ pub mod runner;
 pub mod scanner;
 pub mod update;
 
+pub use baseline::{create_baseline, Baseline, BaselineEntry, BASELINE_FILE};
 pub use config::{CommandConfig, ForgeGuardConfig, GuardMode};
 pub use detector::{detect_project, ProjectDetection};
 pub use doctor::{run_doctor, DoctorReport};

--- a/crates/forgeguard-core/src/model.rs
+++ b/crates/forgeguard-core/src/model.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     Info,
@@ -65,6 +65,7 @@ pub struct GateSummary {
     pub errors: usize,
     pub warnings: usize,
     pub info: usize,
+    pub findings_baselined: usize,
     pub checks_passed: usize,
     pub checks_failed: usize,
 }

--- a/crates/forgeguard-core/src/report.rs
+++ b/crates/forgeguard-core/src/report.rs
@@ -33,6 +33,13 @@ pub fn render_gate(report: &GateReport) -> String {
         "Findings: {} error(s), {} warning(s), {} info",
         report.summary.errors, report.summary.warnings, report.summary.info
     );
+    if report.summary.findings_baselined > 0 {
+        let _ = writeln!(
+            output,
+            "Baseline: {} existing finding(s) hidden",
+            report.summary.findings_baselined
+        );
+    }
     let _ = writeln!(
         output,
         "Checks: {} passed, {} failed",

--- a/crates/forgeguard-core/tests/baseline_test.rs
+++ b/crates/forgeguard-core/tests/baseline_test.rs
@@ -1,0 +1,110 @@
+use std::fs;
+
+use forgeguard_core::{
+    create_baseline, run_gate, ForgeGuardConfig, GateOptions, GateStatus, GuardMode, BASELINE_FILE,
+};
+use tempfile::tempdir;
+
+const EXISTING_FINDING: &str = r#"
+for (const user of users) {
+  await db.query("SELECT id FROM profiles WHERE user_id = ?", [user.id]);
+}
+"#;
+
+#[test]
+fn baseline_hides_existing_finding_after_line_move() {
+    let directory = tempdir().expect("temp directory");
+    let source = directory.path().join("repository.ts");
+    fs::write(&source, EXISTING_FINDING).expect("write source");
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = GuardMode::Strict;
+
+    let baseline = create_baseline(directory.path(), &config.scan, false).expect("create baseline");
+    assert_eq!(baseline.total_findings(), 1);
+
+    fs::write(&source, format!("\n\n{EXISTING_FINDING}")).expect("move finding");
+    let report = run_gate(
+        directory.path(),
+        &config,
+        &GateOptions {
+            skip_commands: true,
+            paths: None,
+        },
+    )
+    .expect("run gate");
+
+    assert_eq!(report.status, GateStatus::Passed);
+    assert!(report.findings.is_empty());
+    assert_eq!(report.summary.findings_baselined, 1);
+}
+
+#[test]
+fn baseline_reports_additional_matching_finding() {
+    let directory = tempdir().expect("temp directory");
+    let source = directory.path().join("repository.ts");
+    fs::write(&source, EXISTING_FINDING).expect("write source");
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = GuardMode::Strict;
+    create_baseline(directory.path(), &config.scan, false).expect("create baseline");
+
+    fs::write(
+        &source,
+        r#"
+for (const user of users) {
+  await db.query("SELECT id FROM profiles WHERE user_id = ?", [user.id]);
+  await db.query("SELECT id FROM profiles WHERE user_id = ?", [user.id]);
+}
+"#,
+    )
+    .expect("add matching finding");
+    let report = run_gate(
+        directory.path(),
+        &config,
+        &GateOptions {
+            skip_commands: true,
+            paths: None,
+        },
+    )
+    .expect("run gate");
+
+    assert_eq!(report.status, GateStatus::Blocked);
+    assert_eq!(report.findings.len(), 1);
+    assert_eq!(report.summary.findings_baselined, 1);
+}
+
+#[test]
+fn replacing_baseline_requires_force() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(directory.path().join("repository.ts"), EXISTING_FINDING).expect("write source");
+    let config = ForgeGuardConfig::new("sample", Vec::new());
+
+    create_baseline(directory.path(), &config.scan, false).expect("create baseline");
+    let error = create_baseline(directory.path(), &config.scan, false)
+        .expect_err("replacement should require force");
+    assert!(error.to_string().contains("--force"));
+    create_baseline(directory.path(), &config.scan, true).expect("replace baseline");
+}
+
+#[test]
+fn gate_rejects_unknown_baseline_version() {
+    let directory = tempdir().expect("temp directory");
+    fs::create_dir_all(directory.path().join(".forgeguard")).expect("create baseline directory");
+    fs::write(
+        directory.path().join(BASELINE_FILE),
+        r#"{"version":99,"findings":[]}"#,
+    )
+    .expect("write baseline");
+    let config = ForgeGuardConfig::new("sample", Vec::new());
+
+    let error = run_gate(
+        directory.path(),
+        &config,
+        &GateOptions {
+            skip_commands: true,
+            paths: None,
+        },
+    )
+    .expect_err("unsupported baseline should fail");
+
+    assert!(error.to_string().contains("unsupported baseline version"));
+}

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -57,6 +57,7 @@ fn installs_configuration_for_all_supported_agents() {
         .path()
         .join(".agents/skills/forgeguard-engineering/references/mobile.md")
         .exists());
+    assert!(!directory.path().join(".gitignore").exists());
     let algorithm_policy = fs::read_to_string(
         directory
             .path()
@@ -68,6 +69,45 @@ fn installs_configuration_for_all_supported_agents() {
     let doctor = forgeguard_core::run_doctor(directory.path(), None).expect("run doctor");
     assert!(doctor.hooks.iter().all(|hook| hook.configured));
     assert!(!report.files_written.is_empty());
+}
+
+#[test]
+fn project_init_appends_installed_agent_directories_to_existing_gitignore() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(directory.path().join(".gitignore"), "target/\n/.codex/\n").expect("write gitignore");
+    let options = InitOptions {
+        force: false,
+        agents: vec![AgentTarget::All],
+    };
+
+    let report = initialize_project(directory.path(), &options).expect("first initialization");
+    initialize_project(directory.path(), &options).expect("second initialization");
+
+    assert_eq!(
+        fs::read_to_string(directory.path().join(".gitignore")).expect("read gitignore"),
+        "target/\n/.codex/\n.claude/\n.cursor/\n.agents/\n"
+    );
+    assert!(report.files_written.contains(&".gitignore".to_owned()));
+}
+
+#[test]
+fn project_init_ignores_only_directories_for_selected_agents() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(directory.path().join(".gitignore"), "target/\r\n").expect("write gitignore");
+
+    initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: false,
+            agents: vec![AgentTarget::Claude],
+        },
+    )
+    .expect("initialize Claude");
+
+    assert_eq!(
+        fs::read_to_string(directory.path().join(".gitignore")).expect("read gitignore"),
+        "target/\r\n.claude/\r\n"
+    );
 }
 
 #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,7 @@ request
   → implementation cycle
   → Stop hook
   → changed-source scanning
+  → committed baseline filtering
   → configured quality commands
   → mode-aware gate decision
   → silent pass or bounded agent feedback

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -46,4 +46,9 @@ A reviewed heuristic can be suppressed on its line or the preceding line with a 
 // forgeguard: allow FG-ALG-001 -- bounded inner loop; maximum 8 items
 ```
 
-Error-level findings and command failures cannot be suppressed.
+Error-level findings and command failures cannot be suppressed inline.
+
+For an existing repository, `forgeguard baseline create` records current static findings in
+`.forgeguard/baseline.json`. Later gates hide matching existing findings while still reporting
+additional occurrences, changed evidence, and all command failures. Commit the baseline so local
+and CI gates enforce the same boundary.


### PR DESCRIPTION
## What changed

- add committed finding baselines with `forgeguard baseline create`
- keep gates focused on new or additional findings
- append generated agent directories to an existing project `.gitignore` without creating one
- bump workspace version to `0.6.0`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace` (73 tests)
- `cargo build --locked --workspace`
- `sh -n install.sh`
- `sh tests/install_test.sh`
- `forgeguard gate --changed --output compact`