### PR TITLE
chore: release v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]


### PR DESCRIPTION
Patch release. Bumps workspace version 0.6.0 → 0.6.1 for the two refactor commits since v0.6.0:
- refactor: streamline engineering guidance (d45745e)
- refactor: prune obsolete skill asset (5043e56)

Tag v0.6.1 to be created on the merge commit after this lands.