### PR TITLE
feat: ForgeGuard logo and update workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
-# ForgeGuard
+# ForgeGuard — engineering discipline for AI coding agents
 
-**Token-efficient engineering discipline for AI coding agents.**
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/brand/logo-dark.svg">
+    <img src="assets/brand/logo-light.svg" alt="ForgeGuard" width="360">
+  </picture>
+</p>
+
+<p align="center">
+  <strong>Token-efficient quality layer for AI coding agents.<br>Codex · Claude Code · Cursor · OpenCode · Antigravity — one Rust binary, no LLM calls.</strong>
+</p>
 
 ForgeGuard is a language- and framework-agnostic quality layer for Codex, Claude Code, Cursor, OpenCode, Antigravity, and agents that support `AGENTS.md` or Agent Skills. It applies to backend services, web frontends, native and cross-platform mobile apps, AI systems, data code, automation scripts, CLIs, and infrastructure code.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,65 @@ Installers use GitHub Release binaries produced for Linux, macOS, and Windows on
 cargo install --path crates/forgeguard-cli
 ```
 
+## Updating
+
+`forgeguard update` only *checks* whether a newer release exists and prints a one-line
+notice; it never installs anything. Upgrading is re-running the installer, then refreshing the
+assets ForgeGuard already wrote.
+
+### Upgrade the binary and global assets
+
+Re-run the one-line installer. It downloads the latest release binary for the current OS and
+CPU, verifies its SHA-256 checksum, and updates the user `PATH`.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/suiflex/ForgeGuard/main/install.sh | sh
+```
+
+```powershell
+irm https://raw.githubusercontent.com/suiflex/ForgeGuard/main/install.ps1 | iex
+```
+
+The installer refreshes the binary but does not overwrite global rules or skills that already
+exist. To re-apply the newer bundled global skills, policies, and hooks over an existing global
+install, force it:
+
+```bash
+forgeguard init --global --agent all --force
+```
+
+Source builds upgrade with:
+
+```bash
+cargo install --path crates/forgeguard-cli
+```
+
+Check the installed version at any time:
+
+```bash
+forgeguard update
+```
+
+### Refresh an already-initialized project
+
+New releases can ship updated policy files and engineering skills. A plain `forgeguard init`
+never overwrites existing ForgeGuard files, so re-initialize with `--force` to pull the newer
+bundle into a repository that was set up by an older version:
+
+```bash
+cd your-project
+forgeguard init --agent all --force
+forgeguard doctor
+```
+
+`--force` overwrites the ForgeGuard-owned policy and skill files and prunes obsolete
+role-skill directories.
+
+> **Warning:** `--force` also regenerates `.forgeguard/config.toml` from detection defaults,
+> resetting any custom commands and operating mode. If you customized the config, back it up
+> first, or re-apply the mode afterward with `forgeguard mode default|lite|strict`. A committed
+> `.forgeguard/baseline.json` is not touched.
+
 ## Quick start
 
 ```bash

--- a/assets/brand/logo-dark.svg
+++ b/assets/brand/logo-dark.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 64" role="img" aria-label="ForgeGuard — engineering discipline for AI coding agents">
+  <rect x="0" y="6" width="52" height="52" rx="12" fill="#0a0a0a"/>
+  <g transform="translate(0 6) scale(1.625)">
+    <path d="M8 8.5 H24 V17 C24 22 20.5 24.8 16 26.5 C11.5 24.8 8 22 8 17 Z" fill="#4ade80"/>
+    <g fill="none" stroke="#0a0a0a" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9.6 10.2 L13.2 12.4" stroke-width="2.8"/>
+      <path d="M13.2 12.4 C 19 13.2, 20 18, 15.4 18.2 C 12.4 18.3, 13 21.4, 18.4 21.6" stroke-width="1.9"/>
+      <path d="M18.4 21.6 L21.2 20.8 M18.4 21.6 L19.9 23.9" stroke-width="1.5"/>
+    </g>
+  </g>
+  <text x="66" y="44" font-family="'Geist Sans','Inter','SF Pro Display',system-ui,-apple-system,sans-serif" font-size="34" font-weight="700" letter-spacing="-0.8">
+    <tspan fill="#fafafa">Forge</tspan><tspan fill="#4ade80">Guard</tspan>
+  </text>
+</svg>

--- a/assets/brand/logo-light.svg
+++ b/assets/brand/logo-light.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 64" role="img" aria-label="ForgeGuard — engineering discipline for AI coding agents">
+  <rect x="0" y="6" width="52" height="52" rx="12" fill="#0a0a0a"/>
+  <g transform="translate(0 6) scale(1.625)">
+    <path d="M8 8.5 H24 V17 C24 22 20.5 24.8 16 26.5 C11.5 24.8 8 22 8 17 Z" fill="#4ade80"/>
+    <g fill="none" stroke="#0a0a0a" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9.6 10.2 L13.2 12.4" stroke-width="2.8"/>
+      <path d="M13.2 12.4 C 19 13.2, 20 18, 15.4 18.2 C 12.4 18.3, 13 21.4, 18.4 21.6" stroke-width="1.9"/>
+      <path d="M18.4 21.6 L21.2 20.8 M18.4 21.6 L19.9 23.9" stroke-width="1.5"/>
+    </g>
+  </g>
+  <text x="66" y="44" font-family="'Geist Sans','Inter','SF Pro Display',system-ui,-apple-system,sans-serif" font-size="34" font-weight="700" letter-spacing="-0.8">
+    <tspan fill="#0a0a0a">Forge</tspan><tspan fill="#16a34a">Guard</tspan>
+  </text>
+</svg>

--- a/assets/brand/logo-mark.svg
+++ b/assets/brand/logo-mark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="ForgeGuard">
+  <rect width="32" height="32" rx="7" fill="#0a0a0a"/>
+  <path d="M8 8.5 H24 V17 C24 22 20.5 24.8 16 26.5 C11.5 24.8 8 22 8 17 Z" fill="#4ade80"/>
+  <g fill="none" stroke="#0a0a0a" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M9.6 10.2 L13.2 12.4" stroke-width="2.8"/>
+    <path d="M13.2 12.4 C 19 13.2, 20 18, 15.4 18.2 C 12.4 18.3, 13 21.4, 18.4 21.6" stroke-width="1.9"/>
+    <path d="M18.4 21.6 L21.2 20.8 M18.4 21.6 L19.9 23.9" stroke-width="1.5"/>
+  </g>
+</svg>

--- a/assets/brand/logo.svg
+++ b/assets/brand/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 64" role="img" aria-label="ForgeGuard — engineering discipline for AI coding agents">
+  <rect x="0" y="6" width="52" height="52" rx="12" fill="#0a0a0a"/>
+  <g transform="translate(0 6) scale(1.625)">
+    <path d="M8 8.5 H24 V17 C24 22 20.5 24.8 16 26.5 C11.5 24.8 8 22 8 17 Z" fill="#4ade80"/>
+    <g fill="none" stroke="#0a0a0a" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9.6 10.2 L13.2 12.4" stroke-width="2.8"/>
+      <path d="M13.2 12.4 C 19 13.2, 20 18, 15.4 18.2 C 12.4 18.3, 13 21.4, 18.4 21.6" stroke-width="1.9"/>
+      <path d="M18.4 21.6 L21.2 20.8 M18.4 21.6 L19.9 23.9" stroke-width="1.5"/>
+    </g>
+  </g>
+  <text x="66" y="44" font-family="'Geist Sans','Inter','SF Pro Display',system-ui,-apple-system,sans-serif" font-size="34" font-weight="700" letter-spacing="-0.8">
+    <tspan fill="#fafafa">Forge</tspan><tspan fill="#4ade80">Guard</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
## Summary

- Add the ForgeGuard brand mark and wordmark, matching the shared suiflex system (rdb, suitest).
- Give the README a proper brand header and a missing **Updating** guide.

## Changes

- **assets/brand/** — `logo-mark.svg`, `logo-dark.svg`, `logo-light.svg`, `logo.svg`. Dark tile, `#4ade80` accent, Geist wordmark; the mark places a whip inside the guard shield to signal enforced engineering discipline.
- **README.md** — centered logo + tagline header under the title.
- **README.md** — new `## Updating` section: clarifies `forgeguard update` is check-only, then documents upgrading the binary, refreshing global assets with `init --global --agent all --force`, and re-initializing a project with `init --agent all --force`. Warns that `--force` regenerates `.forgeguard/config.toml`.

## Test plan

- [x] Rendered all SVGs; mark and wordmark display correctly on dark and light.
- [x] Verified every command in the Updating section exists in the CLI (`forgeguard update`, `init --force`, `--global`, `doctor`, `mode`).
- [x] Confirm logos resolve in the rendered README on GitHub.