### PR TITLE
docs(cli): clarify update checks only, init --force refreshes skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ cargo install --path crates/forgeguard-cli
 Check the installed version at any time:
 
 ```bash
+forgeguard --version
+```
+
+Check whether a newer release exists (checks only; installs nothing):
+
+```bash
 forgeguard update
 ```
 

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -35,6 +35,10 @@ struct Cli {
 enum Commands {
     /// Install ForgeGuard skills globally or initialize a repository.
     Init {
+        /// Overwrite ForgeGuard-owned policy and skill files with the bundled
+        /// versions and prune obsolete role-skill directories. Also regenerates
+        /// .forgeguard/config.toml from detection defaults, resetting custom
+        /// commands and mode. Use to refresh an existing install after an upgrade.
         #[arg(long)]
         force: bool,
         /// Install rules, skills, and hooks for supported agents under the user directory.
@@ -94,6 +98,10 @@ enum Commands {
         command: HookCommands,
     },
     /// Check for a newer ForgeGuard release (optional; never required).
+    ///
+    /// Only checks and prints a notice; it installs nothing. To upgrade, re-run
+    /// the installer, then `forgeguard init --force` to refresh skills and
+    /// policies. Use `forgeguard --version` to see the installed version.
     Update,
 }
 

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -33,7 +33,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
-    /// Install ForgeGuard skills globally or initialize a repository.
+    /// Install or refresh ForgeGuard for a repo or globally (--force to refresh after an upgrade).
     Init {
         /// Overwrite ForgeGuard-owned policy and skill files with the bundled
         /// versions and prune obsolete role-skill directories. Also regenerates
@@ -97,7 +97,7 @@ enum Commands {
         #[command(subcommand)]
         command: HookCommands,
     },
-    /// Check for a newer ForgeGuard release (optional; never required).
+    /// Check for a newer release (checks only; installs nothing).
     ///
     /// Only checks and prints a notice; it installs nothing. To upgrade, re-run
     /// the installer, then `forgeguard init --force` to refresh skills and


### PR DESCRIPTION
## Summary

- `forgeguard update` only checks for a newer release and installs nothing, but neither `--help` nor the README made that clear.
- The `init --force` flag — the one that actually refreshes bundled skills and policies — had no `--help` text at all.

## Changes

- **`crates/forgeguard-cli/src/main.rs`**: document `--force` in `init --help` (overwrites policy/skill files, prunes obsolete role-skill dirs, regenerates `.forgeguard/config.toml`); expand the `update` help to state it installs nothing and point at the installer + `init --force`.
- **`README.md`**: use `forgeguard --version` for the installed version and label `forgeguard update` as a checks-only release check.

## Test plan

- [x] `cargo run -p forgeguard -- init --help` shows `--force` text
- [x] `cargo run -p forgeguard -- update --help` shows the checks-only note
- [x] `cargo run -p forgeguard -- --version` prints installed version
- [x] `forgeguard gate --changed --output compact` passes
- [x] Full diff reviewed — docs-only, no logic touched