### PR TITLE
feat: add persistent anti-drift agent loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ ForgeGuard is designed not to drain user context or model limits:
 
 - The hook runs a local Rust binary and repository commands; ForgeGuard itself makes no LLM or external API call.
 - Always-on policy stays compact; detailed backend, frontend, mobile, database, algorithm, testing, and AI references load only when relevant.
-- Passing hooks add no model context in Codex/Claude; Cursor and Antigravity receive only their required minimal protocol response.
+- Passing completion hooks add no model context in Codex/Claude; objective reinjection caps objective text at 300 characters, and scope feedback appears only for an explicit out-of-scope path.
+- Antigravity injects focus context only on the first model invocation of an execution.
 - Blocking feedback is deduplicated and capped at 2,000 characters and five findings.
+- Auto-poke is default-on and creates one host request per continuation; the generated limit is three and the hard cap is five.
 - Full evidence stays local in `.forgeguard/reports/latest.json`.
 - Unchanged worktrees use a local fingerprint cache instead of rerunning the gate.
 
@@ -61,6 +63,7 @@ A blocked gate may cause the host agent to use another turn to fix real failures
 - OpenCode `AGENTS.md` plus shared project skills.
 - Antigravity rule, shared project skill, and native `Stop` hook.
 - Token-efficient `Stop` hooks: silent pass, bounded failure feedback, diff cache, and local full report.
+- Session-scoped objective, todo, confidence, hill-climbability, auto-poke, resume, and scope-drift state.
 - One `forgeguard-engineering` skill with conditional clean-code, algorithm, backend, frontend, mobile, database, AI, and testing references.
 - Static rules for nested iteration, repeated linear lookup, sorting in loops, database I/O in loops, external requests in loops, unbounded fan-out, `SELECT *`, and potential duplicated blocks.
 - Automatic formatter, linter, type-check, test, and build command discovery.
@@ -278,6 +281,15 @@ include_tests = false
 extra_excludes = ["generated/"]
 duplicate_block_lines = 6
 
+[focus]
+enabled = true
+max_retries = 3
+no_progress_limit = 2
+auto_poke = true
+max_auto_pokes = 3
+min_confidence = 80
+min_hill_climbability = 80
+
 [[commands]]
 name = "lint"
 command = "pnpm lint"
@@ -301,6 +313,22 @@ ForgeGuard supports three operating modes:
 - `strict`: strong guard mode. Failed required commands and error-level deterministic findings block.
 
 Older configs with `mode = "guard"` still load as `strict` for compatibility.
+
+Focus state and scope checks are local and make no LLM calls. `max_retries` bounds corrective turns; `no_progress_limit` stops a session that produces no repository or task-state progress. `auto_poke` is enabled automatically by `forgeguard init`; each continuation creates a new host request and consumes model tokens, so `max_auto_pokes` defaults to three and has a hard cap of five. Set `auto_poke = false` only when manually opting out. Pending todos, confidence below `min_confidence`, or goal-contract completeness below `min_hill_climbability` keep the task active. Hill-climbability is a deterministic 0–100 completeness score: metric, baseline, target, guardrail, and verification contribute 20 points each. ForgeGuard does not guess these fields from prose. `forgeguard task start --semantic` only asks a supported host to use its native goal evaluator.
+
+See [Focus, auto-poke, and hill-climbability](docs/FOCUS.md) for the lifecycle, headless behavior, token bounds, upgrade path, and examples.
+
+Example measurable task:
+
+```bash
+forgeguard task start --session "$SESSION" \
+  --objective "Reduce /search latency without regressions" \
+  --metric "p95 latency /search" --baseline "900 ms" --target "below 300 ms" \
+  --guardrail "error rate does not increase" --verification "regression tests pass" \
+  --todo "measure baseline" --todo "optimize endpoint"
+forgeguard task todo --session "$SESSION" --done 1
+forgeguard task ready --session "$SESSION" --confidence 90 --evidence "benchmark: p95 284 ms"
+```
 
 Set project mode:
 
@@ -336,7 +364,11 @@ When run in a terminal without an explicit mode, `forgeguard mode` opens the sam
 | `forgeguard gate` | Run static rules and configured quality commands. |
 | `forgeguard review` | Scan Git-changed files without running commands. |
 | `forgeguard baseline create` | Record current static findings so gates report only new findings. |
-| `forgeguard hook stop` | Internal token-efficient lifecycle adapter for supported agents. |
+| `forgeguard task start` | Register objective, goal metrics, todos, and optional scope prefixes. |
+| `forgeguard task todo` | Add todos or mark 1-based todo indexes complete. |
+| `forgeguard task ready` | Submit exact evidence and optional model confidence before the completion gate. |
+| `forgeguard task status` | Inspect session-scoped objective state. |
+| `forgeguard hook stop/context/scope` | Internal lifecycle adapters for completion, objective restoration, and scope warnings. |
 
 ## Agent contract
 
@@ -346,6 +378,8 @@ Developer
 Claude Code / Codex / Cursor / OpenCode / Antigravity
   ↓
 ForgeGuard compact rules + conditional skill + Stop hook
+  ↓
+session objective + goal metric + todo state + confidence history + executed evidence
   ↓
 Repository tools
   ↓

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -9,12 +9,15 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use forgeguard_core::{
     config::{ForgeGuardConfig, CONFIG_FILE},
-    create_baseline, detect_project, evaluate_stop_hook,
+    create_baseline, detect_project, evaluate_context_hook, evaluate_scope_hook,
+    evaluate_stop_hook,
     git::changed_files,
-    initialize_global, initialize_project, render_hook_decision,
+    initialize_global, initialize_project, mark_task_ready_with_confidence, render_context_hook,
+    render_hook_decision, render_scope_warning,
     report::{render_detection, render_doctor, render_gate, render_gate_compact},
-    run_doctor, run_gate, AgentTarget, GateOptions, GateReport, GateStatus, GuardMode, HookAgent,
-    HookDecision, InitOptions, BASELINE_FILE,
+    run_doctor, run_gate, start_task_with_contract, task_state, update_task_todos, AgentTarget,
+    GateOptions, GateReport, GateStatus, GoalContract, GuardMode, HookAgent, HookDecision,
+    InitOptions, BASELINE_FILE,
 };
 
 #[derive(Debug, Parser)]
@@ -97,6 +100,11 @@ enum Commands {
         #[command(subcommand)]
         command: HookCommands,
     },
+    /// Track a session objective, scope, and evidence for bounded agent work.
+    Task {
+        #[command(subcommand)]
+        command: Box<TaskCommands>,
+    },
     /// Check for a newer release (checks only; installs nothing).
     ///
     /// Only checks and prints a notice; it installs nothing. To upgrade, re-run
@@ -136,6 +144,84 @@ enum HookCommands {
     Stop {
         #[arg(long, value_enum)]
         agent: HookAgentArg,
+    },
+    /// Inject the active objective when a session starts, resumes, or compacts.
+    Context {
+        #[arg(long, value_enum)]
+        agent: HookAgentArg,
+    },
+    /// Warn when a file edit falls outside the declared task path prefixes.
+    Scope {
+        #[arg(long, value_enum)]
+        agent: HookAgentArg,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum TaskCommands {
+    /// Register the exact objective before a non-trivial code change.
+    Start {
+        #[arg(long)]
+        session: String,
+        #[arg(long)]
+        objective: String,
+        /// Repository-relative path prefix. Repeat for multiple scopes.
+        #[arg(long = "scope")]
+        scopes: Vec<String>,
+        /// Ask the host's native goal evaluator to track semantic completion.
+        #[arg(long)]
+        semantic: bool,
+        /// Progress metric, such as p95 latency or failing regression count.
+        #[arg(long)]
+        metric: Option<String>,
+        /// Current measured state.
+        #[arg(long)]
+        baseline: Option<String>,
+        /// Verifiable target state.
+        #[arg(long)]
+        target: Option<String>,
+        /// Constraint that must not regress. Repeat for multiple guardrails.
+        #[arg(long = "guardrail")]
+        guardrails: Vec<String>,
+        /// Exact verification method. Repeat for multiple checks.
+        #[arg(long = "verification")]
+        verifications: Vec<String>,
+        /// Verifiable work item. Repeat for multiple todos.
+        #[arg(long = "todo")]
+        todos: Vec<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Mark implementation ready for ForgeGuard's deterministic completion gate.
+    Ready {
+        #[arg(long)]
+        session: String,
+        /// Exact executed check or tool result. Repeat for multiple evidence items.
+        #[arg(long = "evidence")]
+        evidence: Vec<String>,
+        /// Model-reported confidence; tracked but never replaces evidence or gates.
+        #[arg(long)]
+        confidence: Option<u8>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Add todos or mark 1-based todo indexes complete.
+    Todo {
+        #[arg(long)]
+        session: String,
+        #[arg(long = "add")]
+        additions: Vec<String>,
+        #[arg(long = "done")]
+        completed: Vec<usize>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show the current session task state.
+    Status {
+        #[arg(long)]
+        session: String,
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -329,6 +415,13 @@ fn execute() -> Result<ExitCode> {
         Commands::Hook {
             command: HookCommands::Stop { agent },
         } => execute_stop_hook(&root, agent.into()),
+        Commands::Hook {
+            command: HookCommands::Context { agent },
+        } => execute_context_hook(&root, agent.into()),
+        Commands::Hook {
+            command: HookCommands::Scope { agent },
+        } => execute_scope_hook(&root, agent.into()),
+        Commands::Task { command } => execute_task(&root, *command),
         Commands::Update => {
             let home = home_directory()?;
             match forgeguard_core::update::refresh(&home, true) {
@@ -471,10 +564,103 @@ fn execute_stop_hook(root: &Path, agent: HookAgent) -> Result<ExitCode> {
             HookDecision::Block(append_update_notice(reason, home.as_deref()))
         }
         HookDecision::Pass => HookDecision::Pass,
+        HookDecision::Stop(reason) => HookDecision::Stop(reason),
     };
     let output = render_hook_decision(agent, &decision);
     if !output.is_empty() {
         println!("{output}");
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn execute_context_hook(root: &Path, agent: HookAgent) -> Result<ExitCode> {
+    let mut input = String::new();
+    io::stdin()
+        .read_to_string(&mut input)
+        .context("failed to read hook input")?;
+    if let Some(context) = evaluate_context_hook(root, &input, agent)? {
+        println!("{}", render_context_hook(agent, &input, &context));
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn execute_scope_hook(root: &Path, agent: HookAgent) -> Result<ExitCode> {
+    let mut input = String::new();
+    io::stdin()
+        .read_to_string(&mut input)
+        .context("failed to read hook input")?;
+    if let Some(warning) = evaluate_scope_hook(root, &input)? {
+        println!("{}", render_scope_warning(agent, &warning));
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn execute_task(root: &Path, command: TaskCommands) -> Result<ExitCode> {
+    let (task, json) = match command {
+        TaskCommands::Start {
+            session,
+            objective,
+            scopes,
+            semantic,
+            metric,
+            baseline,
+            target,
+            guardrails,
+            verifications,
+            todos,
+            json,
+        } => (
+            start_task_with_contract(
+                root,
+                &session,
+                &objective,
+                &scopes,
+                semantic,
+                GoalContract {
+                    metric,
+                    baseline,
+                    target,
+                    guardrails,
+                    verifications,
+                },
+                &todos,
+            )?,
+            json,
+        ),
+        TaskCommands::Ready {
+            session,
+            evidence,
+            confidence,
+            json,
+        } => (
+            mark_task_ready_with_confidence(root, &session, &evidence, confidence)?,
+            json,
+        ),
+        TaskCommands::Todo {
+            session,
+            additions,
+            completed,
+            json,
+        } => (
+            update_task_todos(root, &session, &additions, &completed)?,
+            json,
+        ),
+        TaskCommands::Status { session, json } => {
+            let task = task_state(root, &session)?
+                .with_context(|| format!("no ForgeGuard task found for session {session}"))?;
+            (task, json)
+        }
+    };
+    if json {
+        println!("{}", serde_json::to_string_pretty(&task)?);
+    } else {
+        println!(
+            "ForgeGuard task {}: {}",
+            task.session_id,
+            serde_json::to_value(&task)?["status"]
+                .as_str()
+                .unwrap_or("unknown")
+        );
     }
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/forgeguard-core/assets/skills/engineering/SKILL.md
+++ b/crates/forgeguard-core/assets/skills/engineering/SKILL.md
@@ -9,7 +9,13 @@ Follow: inspect → design → implement → test → review → verify.
 
 Inspect the affected code, callers, tests, contracts, and schemas before editing. Reuse only behavior with the same purpose and change reasons; inspect every caller before changing shared behavior. Define relevant bounds, failures, complexity, I/O, concurrency, and the smallest safe design.
 
+For every code change in strict mode, and every non-trivial code change in other modes, use the ForgeGuard session id injected by the lifecycle hook to register the exact objective, verifiable todos, and optional path prefixes with `forgeguard task start`. For abstract work, also state the metric, baseline, target, guardrails, and verification so progress is hill-climbable. Keep the declared scope honest; expand it only after repository evidence shows the objective requires another path. Use `--semantic` only when the host provides a native goal evaluator.
+
 Implement focused changes and proportionate tests. Run `forgeguard gate --changed --output compact` plus relevant repository checks, review the complete diff, and report only executed checks and unresolved risk. Never weaken quality or security controls.
+
+Update completed todos with `forgeguard task todo`. Before stopping, run `forgeguard task ready --session <id> --confidence <0-100> --evidence <exact-check-result>` for an active task. Confidence is model-reported and advisory; it never replaces executed evidence. Never present a model-derived value, correction, or completion claim as fact: cite exact tool/check evidence or label the claim unverified.
+
+Treat an auto-poke as a new bounded verification phase: perform the requested TODO, test, review, or contract check, then submit fresh evidence. Do not repeat an earlier completion claim.
 
 Read only the matching reference; do not read references for routine inspection, reuse, or testing:
 

--- a/crates/forgeguard-core/assets/skills/engineering/references/ai.md
+++ b/crates/forgeguard-core/assets/skills/engineering/references/ai.md
@@ -5,6 +5,8 @@ Act as a Senior AI Engineer. Treat model and tool output as untrusted data.
 - Centralize provider integration at the appropriate scope with explicit model, timeout, retry, rate-limit, token, usage, and fallback policies.
 - Validate structured output with a schema and business rules before writes, tools, commands, or trusted rendering.
 - Version production prompts and define input/output contracts.
+- Treat self-corrections as new claims: require exact tool, calculation, or source evidence before presenting revised values as facts.
+- Treat model confidence as advisory history, never as proof or a replacement for deterministic evidence.
 - For agents and MCP, validate arguments, separate read/write capability, enforce allowlists, iteration limits, timeouts, audit logs, idempotency, and destructive-action policy.
 - For RAG, enforce permissions, tenant filters, chunk metadata, embedding consistency, retrieval evaluation, citations, and stale-index handling.
 - Bound concurrency, deduplicate requests, cache only when safe, and measure latency, tokens, cost, schema validity, faithfulness, relevance, and regressions.

--- a/crates/forgeguard-core/src/config.rs
+++ b/crates/forgeguard-core/src/config.rs
@@ -74,6 +74,38 @@ pub struct CommandConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FocusConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_focus_max_retries")]
+    pub max_retries: u32,
+    #[serde(default = "default_focus_no_progress_limit")]
+    pub no_progress_limit: u32,
+    #[serde(default = "default_true")]
+    pub auto_poke: bool,
+    #[serde(default = "default_focus_max_auto_pokes")]
+    pub max_auto_pokes: u32,
+    #[serde(default = "default_focus_min_confidence")]
+    pub min_confidence: u8,
+    #[serde(default = "default_focus_min_hill_climbability")]
+    pub min_hill_climbability: u8,
+}
+
+impl Default for FocusConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_retries: default_focus_max_retries(),
+            no_progress_limit: default_focus_no_progress_limit(),
+            auto_poke: true,
+            max_auto_pokes: default_focus_max_auto_pokes(),
+            min_confidence: default_focus_min_confidence(),
+            min_hill_climbability: default_focus_min_hill_climbability(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ForgeGuardConfig {
     #[serde(default = "default_config_version")]
     pub version: u32,
@@ -84,6 +116,8 @@ pub struct ForgeGuardConfig {
     pub scan: ScanConfig,
     #[serde(default)]
     pub commands: Vec<CommandConfig>,
+    #[serde(default)]
+    pub focus: FocusConfig,
 }
 
 impl ForgeGuardConfig {
@@ -96,6 +130,7 @@ impl ForgeGuardConfig {
             },
             scan: ScanConfig::default(),
             commands,
+            focus: FocusConfig::default(),
         }
     }
 
@@ -150,4 +185,24 @@ fn default_duplicate_block_lines() -> usize {
 
 fn default_command_timeout_seconds() -> u64 {
     600
+}
+
+fn default_focus_max_retries() -> u32 {
+    3
+}
+
+fn default_focus_no_progress_limit() -> u32 {
+    2
+}
+
+fn default_focus_max_auto_pokes() -> u32 {
+    3
+}
+
+fn default_focus_min_confidence() -> u8 {
+    80
+}
+
+fn default_focus_min_hill_climbability() -> u8 {
+    80
 }

--- a/crates/forgeguard-core/src/doctor.rs
+++ b/crates/forgeguard-core/src/doctor.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     config::{ForgeGuardConfig, CONFIG_FILE},
     init::{
-        ANTIGRAVITY_HOOK_COMMAND, CLAUDE_HOOK_COMMAND, CODEX_HOOK_COMMAND, CURSOR_HOOK_COMMAND,
+        ANTIGRAVITY_CONTEXT_HOOK_COMMAND, ANTIGRAVITY_HOOK_COMMAND, ANTIGRAVITY_SCOPE_HOOK_COMMAND,
+        CLAUDE_CONTEXT_HOOK_COMMAND, CLAUDE_HOOK_COMMAND, CLAUDE_SCOPE_HOOK_COMMAND,
+        CODEX_CONTEXT_HOOK_COMMAND, CODEX_HOOK_COMMAND, CODEX_SCOPE_HOOK_COMMAND,
+        CURSOR_CONTEXT_HOOK_COMMAND, CURSOR_HOOK_COMMAND, CURSOR_SCOPE_HOOK_COMMAND,
         LEGACY_SKILL_NAMES,
     },
 };
@@ -89,33 +92,49 @@ fn hook_statuses(root: &Path) -> Vec<HookStatus> {
         (
             "codex",
             ".codex/hooks.json",
-            CODEX_HOOK_COMMAND,
+            [
+                CODEX_HOOK_COMMAND,
+                CODEX_CONTEXT_HOOK_COMMAND,
+                CODEX_SCOPE_HOOK_COMMAND,
+            ],
             shared_skill && root.join("AGENTS.md").is_file(),
         ),
         (
             "claude",
             ".claude/settings.json",
-            CLAUDE_HOOK_COMMAND,
+            [
+                CLAUDE_HOOK_COMMAND,
+                CLAUDE_CONTEXT_HOOK_COMMAND,
+                CLAUDE_SCOPE_HOOK_COMMAND,
+            ],
             root.join(".claude/skills/forgeguard-engineering/SKILL.md")
                 .is_file(),
         ),
         (
             "cursor",
             ".cursor/hooks.json",
-            CURSOR_HOOK_COMMAND,
+            [
+                CURSOR_HOOK_COMMAND,
+                CURSOR_CONTEXT_HOOK_COMMAND,
+                CURSOR_SCOPE_HOOK_COMMAND,
+            ],
             shared_skill && root.join(".cursor/rules/forgeguard.mdc").is_file(),
         ),
         (
             "antigravity",
             ".agents/hooks.json",
-            ANTIGRAVITY_HOOK_COMMAND,
+            [
+                ANTIGRAVITY_HOOK_COMMAND,
+                ANTIGRAVITY_CONTEXT_HOOK_COMMAND,
+                ANTIGRAVITY_SCOPE_HOOK_COMMAND,
+            ],
             shared_skill && root.join(".agents/rules/forgeguard.md").is_file(),
         ),
     ]
     .into_iter()
-    .map(|(agent, relative, command, installed)| {
+    .map(|(agent, relative, commands, installed)| {
         let path = root.join(relative);
-        let configured = fs_contains(&path, command);
+        let configured = commands.iter().all(|command| fs_contains(&path, command));
         HookStatus {
             agent: agent.to_owned(),
             installed,

--- a/crates/forgeguard-core/src/hook.rs
+++ b/crates/forgeguard-core/src/hook.rs
@@ -1,22 +1,40 @@
 use std::{
+    collections::hash_map::DefaultHasher,
     fs,
-    path::{Path, PathBuf},
+    hash::Hasher,
+    path::{Component, Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::{
-    config::{ForgeGuardConfig, CONFIG_FILE},
+    config::{FocusConfig, ForgeGuardConfig, GuardMode, CONFIG_FILE},
     detect_project,
     git::{changed_files, worktree_fingerprint},
     report::{render_gate_compact, COMPACT_MAX_CHARS},
     run_gate, GateOptions, GateStatus,
 };
 
-const CACHE_FILE: &str = ".forgeguard/cache/stop.json";
+const CACHE_DIR: &str = ".forgeguard/cache/stop";
+const TASK_DIR: &str = ".forgeguard/cache/tasks";
 const REPORT_FILE: &str = ".forgeguard/reports/latest.json";
+const MAX_OBJECTIVE_CHARS: usize = 4_000;
+const MAX_EVIDENCE_ITEMS: usize = 8;
+const MAX_EVIDENCE_CHARS: usize = 500;
+const MAX_TASK_ITEMS: usize = 32;
+const MAX_TASK_ITEM_CHARS: usize = 500;
+const MAX_CONFIDENCE_HISTORY: usize = 16;
+const FOCUS_FEEDBACK_RESERVE: usize = 320;
+const MAX_AUTO_POKES: u32 = 5;
+const AUTO_POKE_PHASES: [&str; 5] = [
+    "reinspect the objective and remaining TODOs; fix any concrete gap",
+    "run relevant tests and checks; fix every observed failure",
+    "review the full diff for correctness, regressions, and scope drift",
+    "verify contracts, edge cases, and failure handling against repository evidence",
+    "run final verification and confirm no objective gap remains",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookAgent {
@@ -30,6 +48,7 @@ pub enum HookAgent {
 pub enum HookDecision {
     Pass,
     Block(String),
+    Stop(String),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -37,6 +56,70 @@ struct HookCache {
     fingerprint: String,
     status: GateStatus,
     message: String,
+    attempts: u32,
+    stalled_attempts: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskStatus {
+    Active,
+    Ready,
+    Completed,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct GoalContract {
+    pub metric: Option<String>,
+    pub baseline: Option<String>,
+    pub target: Option<String>,
+    #[serde(default)]
+    pub guardrails: Vec<String>,
+    #[serde(default)]
+    pub verifications: Vec<String>,
+}
+
+impl GoalContract {
+    pub fn hill_climbability(&self) -> u8 {
+        let mut score = 0;
+        score += u8::from(self.metric.is_some()) * 20;
+        score += u8::from(self.baseline.is_some()) * 20;
+        score += u8::from(self.target.is_some()) * 20;
+        score += u8::from(!self.guardrails.is_empty()) * 20;
+        score += u8::from(!self.verifications.is_empty()) * 20;
+        score
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskTodo {
+    pub text: String,
+    pub done: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskState {
+    pub version: u32,
+    pub session_id: String,
+    pub objective: String,
+    pub scopes: Vec<String>,
+    pub semantic: bool,
+    #[serde(default)]
+    pub goal: GoalContract,
+    #[serde(default)]
+    pub todos: Vec<TaskTodo>,
+    #[serde(default)]
+    pub confidence: Option<u8>,
+    #[serde(default)]
+    pub confidence_history: Vec<u8>,
+    #[serde(default)]
+    pub auto_pokes: u32,
+    #[serde(default)]
+    pub poke_instruction: Option<String>,
+    pub status: TaskStatus,
+    pub evidence: Vec<String>,
+    pub blocker: Option<String>,
 }
 
 pub fn evaluate_stop_hook(fallback_root: &Path, input: &str) -> Result<(HookDecision, bool)> {
@@ -44,50 +127,80 @@ pub fn evaluate_stop_hook(fallback_root: &Path, input: &str) -> Result<(HookDeci
     let Some(root) = find_project_root(fallback_root, &payload) else {
         return Ok((HookDecision::Pass, false));
     };
-    let Some(worktree) = worktree_fingerprint(&root)? else {
-        return Ok((HookDecision::Pass, false));
+    let session = session_key(&payload);
+    let mut task = read_task(&root, &session)?;
+    let worktree = worktree_fingerprint(&root)?;
+    if worktree.is_none() {
+        match task.as_ref().map(|task| task.status) {
+            None | Some(TaskStatus::Completed | TaskStatus::Blocked) => {
+                return Ok((HookDecision::Pass, false));
+            }
+            Some(TaskStatus::Ready) => {
+                let config = load_hook_config(&root)?
+                    .unwrap_or_else(|| ForgeGuardConfig::new("project", Vec::new()));
+                let task = task.as_mut().expect("matched ready task");
+                if config.focus.enabled {
+                    if let Some(decision) = ready_auto_poke(&root, task, &config.focus)? {
+                        return Ok((decision, false));
+                    }
+                }
+                task.status = TaskStatus::Completed;
+                write_task(&root, task)?;
+                return Ok((HookDecision::Pass, false));
+            }
+            Some(TaskStatus::Active) => {}
+        }
+    }
+    let config = match load_hook_config(&root)? {
+        Some(config) => config,
+        None if task.is_none() => return Ok((HookDecision::Pass, false)),
+        None => ForgeGuardConfig::new("project", Vec::new()),
     };
-    let fingerprint = format!("{}:{worktree}", env!("CARGO_PKG_VERSION"));
-    let repeated_stop = payload
-        .get("stop_hook_active")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-        || payload
-            .get("loop_count")
-            .and_then(Value::as_u64)
-            .is_some_and(|count| count > 0)
-        || payload
-            .get("executionNum")
-            .and_then(Value::as_u64)
-            .is_some_and(|count| count > 1);
-
-    if let Some(cache) = read_cache(&root) {
+    if config.focus.enabled {
+        if let Some(task) = task
+            .as_mut()
+            .filter(|task| task.status == TaskStatus::Active)
+        {
+            if let Some(decision) = active_auto_poke(&root, task, &config.focus)? {
+                return Ok((decision, false));
+            }
+        }
+    }
+    let fingerprint = format!(
+        "{}:{}:{}",
+        env!("CARGO_PKG_VERSION"),
+        worktree.as_deref().unwrap_or("clean"),
+        task_signature(task.as_ref())
+    );
+    let cache = read_cache(&root, &session);
+    if let Some(cache) = &cache {
+        if cache.fingerprint == fingerprint && cache.status == GateStatus::Blocked {
+            return bounded_block(
+                &root,
+                &session,
+                fingerprint,
+                cache.message.clone(),
+                Some(cache),
+                &config.focus,
+                true,
+            );
+        }
         if cache.fingerprint == fingerprint {
-            let decision = if cache.status == GateStatus::Blocked && !repeated_stop {
-                HookDecision::Block(cache.message)
-            } else {
-                HookDecision::Pass
-            };
-            return Ok((decision, true));
+            return Ok((HookDecision::Pass, true));
         }
     }
 
-    // Explicit config wins; otherwise gate any git repo that contains code using
-    // an auto-detected, in-memory config so no per-repo setup is required.
-    let config = if root.join(CONFIG_FILE).exists() {
-        ForgeGuardConfig::load(&root)?
-    } else {
-        let detection = detect_project(&root)?;
-        if detection.languages.is_empty() {
-            return Ok((HookDecision::Pass, false));
-        }
-        ignore_forgeguard_artifacts(&root)?;
-        let name = root
-            .file_name()
-            .and_then(|value| value.to_str())
-            .unwrap_or("project");
-        ForgeGuardConfig::new(name, detection.suggested_commands)
-    };
+    if worktree.is_none() {
+        return bounded_block(
+            &root,
+            &session,
+            fingerprint,
+            incomplete_task_message(&session),
+            cache.as_ref(),
+            &config.focus,
+            false,
+        );
+    }
     let report = run_gate(
         &root,
         &config,
@@ -97,28 +210,68 @@ pub fn evaluate_stop_hook(fallback_root: &Path, input: &str) -> Result<(HookDeci
         },
     )?;
     write_json(&root.join(REPORT_FILE), &report)?;
-    let message = if report.status == GateStatus::Blocked {
-        compact_failure(&report)
-    } else {
-        String::new()
-    };
-    write_json(
-        &root.join(CACHE_FILE),
+    if report.status == GateStatus::Blocked {
+        return bounded_block(
+            &root,
+            &session,
+            fingerprint,
+            compact_failure(&report),
+            cache.as_ref(),
+            &config.focus,
+            false,
+        );
+    }
+    if config.focus.enabled {
+        match task.as_ref() {
+            Some(task) if task.status == TaskStatus::Active => {
+                return bounded_block(
+                    &root,
+                    &session,
+                    fingerprint,
+                    incomplete_task_message(&session),
+                    cache.as_ref(),
+                    &config.focus,
+                    false,
+                );
+            }
+            None if config.mode == GuardMode::Strict => {
+                return bounded_block(
+                    &root,
+                    &session,
+                    fingerprint,
+                    missing_task_message(&session),
+                    cache.as_ref(),
+                    &config.focus,
+                    false,
+                );
+            }
+            _ => {}
+        }
+        if let Some(task) = task
+            .as_mut()
+            .filter(|task| task.status == TaskStatus::Ready)
+        {
+            if let Some(decision) = ready_auto_poke(&root, task, &config.focus)? {
+                return Ok((decision, false));
+            }
+        }
+    }
+    if let Some(mut task) = task.filter(|task| task.status == TaskStatus::Ready) {
+        task.status = TaskStatus::Completed;
+        write_task(&root, &task)?;
+    }
+    write_cache(
+        &root,
+        &session,
         &HookCache {
             fingerprint,
             status: report.status,
-            message: message.clone(),
+            message: String::new(),
+            attempts: 0,
+            stalled_attempts: 0,
         },
     )?;
-
-    Ok((
-        if report.status == GateStatus::Blocked {
-            HookDecision::Block(message)
-        } else {
-            HookDecision::Pass
-        },
-        false,
-    ))
+    Ok((HookDecision::Pass, false))
 }
 
 pub fn render_hook_decision(agent: HookAgent, decision: &HookDecision) -> String {
@@ -132,16 +285,293 @@ pub fn render_hook_decision(agent: HookAgent, decision: &HookDecision) -> String
         (HookAgent::Cursor, HookDecision::Block(reason)) => {
             json!({"followup_message": reason}).to_string()
         }
-        (HookAgent::Codex, HookDecision::Block(reason)) => json!({
-            "continue": true,
-            "systemMessage": reason
-        })
-        .to_string(),
+        (HookAgent::Codex, HookDecision::Block(reason)) => {
+            json!({"decision": "block", "reason": reason}).to_string()
+        }
         (HookAgent::Antigravity, HookDecision::Block(reason)) => json!({
             "decision": "continue",
             "reason": reason
         })
         .to_string(),
+        (HookAgent::Cursor, HookDecision::Stop(_)) => "{}".to_owned(),
+        (HookAgent::Antigravity, HookDecision::Stop(reason)) => {
+            json!({"decision": "stop", "reason": reason}).to_string()
+        }
+        (_, HookDecision::Stop(reason)) => json!({
+            "continue": false,
+            "stopReason": reason,
+            "systemMessage": reason
+        })
+        .to_string(),
+    }
+}
+
+pub fn start_task(
+    root: &Path,
+    session_id: &str,
+    objective: &str,
+    scopes: &[String],
+    semantic: bool,
+) -> Result<TaskState> {
+    start_task_with_contract(
+        root,
+        session_id,
+        objective,
+        scopes,
+        semantic,
+        GoalContract::default(),
+        &[],
+    )
+}
+
+pub fn start_task_with_contract(
+    root: &Path,
+    session_id: &str,
+    objective: &str,
+    scopes: &[String],
+    semantic: bool,
+    goal: GoalContract,
+    todos: &[String],
+) -> Result<TaskState> {
+    validate_session_id(session_id)?;
+    let objective = objective.trim();
+    if objective.is_empty() {
+        bail!("task objective must not be empty");
+    }
+    if objective.chars().count() > MAX_OBJECTIVE_CHARS {
+        bail!("task objective exceeds {MAX_OBJECTIVE_CHARS} characters");
+    }
+    let mut scopes = scopes
+        .iter()
+        .map(|scope| normalize_scope(scope))
+        .collect::<Result<Vec<_>>>()?;
+    scopes.sort();
+    scopes.dedup();
+    let goal = normalize_goal_contract(goal)?;
+    let todos = normalize_task_items("todo", todos, MAX_TASK_ITEMS)?
+        .into_iter()
+        .map(|text| TaskTodo { text, done: false })
+        .collect();
+    let previous = read_task(root, session_id)?;
+    let (auto_pokes, confidence_history) = previous
+        .filter(|task| task.status != TaskStatus::Completed)
+        .map_or((0, Vec::new()), |task| {
+            (task.auto_pokes, task.confidence_history)
+        });
+    let task = TaskState {
+        version: 1,
+        session_id: session_id.to_owned(),
+        objective: objective.to_owned(),
+        scopes,
+        semantic,
+        goal,
+        todos,
+        confidence: None,
+        confidence_history,
+        auto_pokes,
+        poke_instruction: None,
+        status: TaskStatus::Active,
+        evidence: Vec::new(),
+        blocker: None,
+    };
+    write_task(root, &task)?;
+    Ok(task)
+}
+
+pub fn mark_task_ready(root: &Path, session_id: &str, evidence: &[String]) -> Result<TaskState> {
+    mark_task_ready_with_confidence(root, session_id, evidence, None)
+}
+
+pub fn mark_task_ready_with_confidence(
+    root: &Path,
+    session_id: &str,
+    evidence: &[String],
+    confidence: Option<u8>,
+) -> Result<TaskState> {
+    validate_session_id(session_id)?;
+    if evidence.is_empty() {
+        bail!("at least one executed check or tool result is required as evidence");
+    }
+    if evidence.len() > MAX_EVIDENCE_ITEMS {
+        bail!("task evidence exceeds {MAX_EVIDENCE_ITEMS} items");
+    }
+    let evidence = evidence
+        .iter()
+        .map(|item| {
+            let item = item.trim();
+            if item.is_empty() {
+                bail!("task evidence must not be empty");
+            }
+            if item.chars().count() > MAX_EVIDENCE_CHARS {
+                bail!("task evidence exceeds {MAX_EVIDENCE_CHARS} characters");
+            }
+            Ok(item.to_owned())
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut task = read_task(root, session_id)?
+        .with_context(|| format!("no ForgeGuard task found for session {session_id}"))?;
+    let pending = task.todos.iter().filter(|todo| !todo.done).count();
+    if pending > 0 {
+        bail!("{pending} task todo(s) remain incomplete");
+    }
+    if let Some(confidence) = confidence {
+        if confidence > 100 {
+            bail!("task confidence must be between 0 and 100");
+        }
+        task.confidence = Some(confidence);
+        task.confidence_history.push(confidence);
+        if task.confidence_history.len() > MAX_CONFIDENCE_HISTORY {
+            task.confidence_history.remove(0);
+        }
+    }
+    task.status = TaskStatus::Ready;
+    task.evidence = evidence;
+    task.poke_instruction = None;
+    task.blocker = None;
+    write_task(root, &task)?;
+    Ok(task)
+}
+
+pub fn update_task_todos(
+    root: &Path,
+    session_id: &str,
+    additions: &[String],
+    completed: &[usize],
+) -> Result<TaskState> {
+    validate_session_id(session_id)?;
+    let mut task = read_task(root, session_id)?
+        .with_context(|| format!("no ForgeGuard task found for session {session_id}"))?;
+    let additions = normalize_task_items(
+        "todo",
+        additions,
+        MAX_TASK_ITEMS.saturating_sub(task.todos.len()),
+    )?;
+    let changed = !additions.is_empty() || !completed.is_empty();
+    task.todos.extend(
+        additions
+            .into_iter()
+            .map(|text| TaskTodo { text, done: false }),
+    );
+    for index in completed {
+        if *index == 0 || *index > task.todos.len() {
+            bail!("todo index {index} is outside 1..={}", task.todos.len());
+        }
+        task.todos[*index - 1].done = true;
+    }
+    if !changed {
+        bail!("provide at least one todo addition or completed index");
+    }
+    task.status = TaskStatus::Active;
+    task.confidence = None;
+    task.poke_instruction = None;
+    task.blocker = None;
+    write_task(root, &task)?;
+    Ok(task)
+}
+
+pub fn task_state(root: &Path, session_id: &str) -> Result<Option<TaskState>> {
+    validate_session_id(session_id)?;
+    read_task(root, session_id)
+}
+
+pub fn evaluate_context_hook(
+    fallback_root: &Path,
+    input: &str,
+    agent: HookAgent,
+) -> Result<Option<String>> {
+    let payload: Value = serde_json::from_str(input).unwrap_or(Value::Null);
+    let Some(root) = find_project_root(fallback_root, &payload) else {
+        return Ok(None);
+    };
+    let session = session_key(&payload);
+    let task = read_task(&root, &session)?;
+    if agent == HookAgent::Antigravity
+        && payload
+            .get("invocationNum")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            > 0
+    {
+        return Ok(None);
+    }
+    Ok(Some(match task {
+        Some(task) => task_context(&task),
+        None => format!(
+            "ForgeGuard focus session {session}. For non-trivial code changes, register the objective and verifiable todos before editing: `forgeguard task start --session {session} --objective <goal> --todo <step> [--metric <metric> --baseline <value> --target <value> --verification <check>]`. Never state a correction, number, or completion claim without exact tool/check evidence; label it unverified otherwise."
+        ),
+    }))
+}
+
+pub fn render_context_hook(agent: HookAgent, input: &str, context: &str) -> String {
+    let payload: Value = serde_json::from_str(input).unwrap_or(Value::Null);
+    let event = payload
+        .get("hook_event_name")
+        .and_then(Value::as_str)
+        .unwrap_or("SessionStart");
+    match agent {
+        HookAgent::Codex | HookAgent::Claude => json!({
+            "hookSpecificOutput": {
+                "hookEventName": event,
+                "additionalContext": context
+            }
+        })
+        .to_string(),
+        HookAgent::Cursor => json!({"additional_context": context}).to_string(),
+        HookAgent::Antigravity => {
+            json!({"injectSteps": [{"ephemeralMessage": context}]}).to_string()
+        }
+    }
+}
+
+pub fn evaluate_scope_hook(fallback_root: &Path, input: &str) -> Result<Option<String>> {
+    let payload: Value = serde_json::from_str(input).unwrap_or(Value::Null);
+    let Some(root) = find_project_root(fallback_root, &payload) else {
+        return Ok(None);
+    };
+    let session = session_key(&payload);
+    let Some(task) = read_task(&root, &session)? else {
+        return Ok(None);
+    };
+    if task.status != TaskStatus::Active || task.scopes.is_empty() {
+        return Ok(None);
+    }
+    let tool_input = payload
+        .get("tool_input")
+        .or_else(|| payload.pointer("/toolCall/args"))
+        .unwrap_or(&Value::Null);
+    let mut paths = Vec::new();
+    collect_tool_paths(tool_input, None, &mut paths);
+    paths.extend(patch_paths(tool_input));
+    paths.sort();
+    paths.dedup();
+    let outside = paths
+        .into_iter()
+        .filter_map(|path| normalize_tool_path(&root, &path))
+        .filter(|path| !task.scopes.iter().any(|scope| path_in_scope(path, scope)))
+        .take(3)
+        .collect::<Vec<_>>();
+    if outside.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(format!(
+        "ForgeGuard scope warning for objective `{}`: {} outside declared scope [{}]. Reinspect and expand scope explicitly only when required by the objective.",
+        truncate(&task.objective, 120),
+        outside.join(", "),
+        task.scopes.join(", ")
+    )))
+}
+
+pub fn render_scope_warning(agent: HookAgent, warning: &str) -> String {
+    match agent {
+        HookAgent::Codex | HookAgent::Claude => json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": warning
+            }
+        })
+        .to_string(),
+        HookAgent::Cursor => json!({"permission": "allow", "user_message": warning}).to_string(),
+        HookAgent::Antigravity => json!({"decision": "allow", "reason": warning}).to_string(),
     }
 }
 
@@ -203,16 +633,489 @@ fn find_project_root(fallback_root: &Path, payload: &Value) -> Option<PathBuf> {
 
 fn compact_failure(report: &crate::GateReport) -> String {
     let suffix = "\nFull report: .forgeguard/reports/latest.json";
-    let available = COMPACT_MAX_CHARS.saturating_sub(suffix.chars().count());
+    let available = COMPACT_MAX_CHARS
+        .saturating_sub(suffix.chars().count())
+        .saturating_sub(FOCUS_FEEDBACK_RESERVE);
     let compact = render_gate_compact(report);
     let mut output: String = compact.chars().take(available).collect();
     output.push_str(suffix);
     output
 }
 
-fn read_cache(root: &Path) -> Option<HookCache> {
-    let source = fs::read_to_string(root.join(CACHE_FILE)).ok()?;
+fn load_hook_config(root: &Path) -> Result<Option<ForgeGuardConfig>> {
+    if root.join(CONFIG_FILE).exists() {
+        return ForgeGuardConfig::load(root).map(Some);
+    }
+    let detection = detect_project(root)?;
+    if detection.languages.is_empty() {
+        return Ok(None);
+    }
+    ignore_forgeguard_artifacts(root)?;
+    let name = root
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("project");
+    Ok(Some(ForgeGuardConfig::new(
+        name,
+        detection.suggested_commands,
+    )))
+}
+
+fn bounded_block(
+    root: &Path,
+    session: &str,
+    fingerprint: String,
+    message: String,
+    previous: Option<&HookCache>,
+    focus: &FocusConfig,
+    cache_hit: bool,
+) -> Result<(HookDecision, bool)> {
+    let attempts = previous.map_or(1, |cache| cache.attempts.saturating_add(1));
+    let stalled_attempts = previous.map_or(0, |cache| {
+        if cache.fingerprint == fingerprint {
+            cache.stalled_attempts.saturating_add(1)
+        } else {
+            0
+        }
+    });
+    let max_retries = focus.max_retries.max(1);
+    let no_progress_limit = focus.no_progress_limit.max(1);
+    let exhausted = attempts > max_retries || stalled_attempts >= no_progress_limit;
+    let bounded_message = if exhausted {
+        format!(
+            "{message}\nForgeGuard stopped after {attempts} attempt(s), including {stalled_attempts} without repository or task-state progress. Report the blocker; do not claim completion."
+        )
+    } else {
+        format!(
+            "{message}\nForgeGuard focus attempt {attempts}/{max_retries}; no-progress {stalled_attempts}/{no_progress_limit}. Continue only from verified repository/tool evidence."
+        )
+    };
+    let bounded_message = truncate(&bounded_message, COMPACT_MAX_CHARS);
+    write_cache(
+        root,
+        session,
+        &HookCache {
+            fingerprint,
+            status: GateStatus::Blocked,
+            message,
+            attempts,
+            stalled_attempts,
+        },
+    )?;
+    if exhausted {
+        if let Some(mut task) = read_task(root, session)? {
+            task.status = TaskStatus::Blocked;
+            task.blocker = Some(bounded_message.clone());
+            write_task(root, &task)?;
+        }
+        Ok((HookDecision::Stop(bounded_message), cache_hit))
+    } else {
+        Ok((HookDecision::Block(bounded_message), cache_hit))
+    }
+}
+
+fn active_auto_poke(
+    root: &Path,
+    task: &mut TaskState,
+    focus: &FocusConfig,
+) -> Result<Option<HookDecision>> {
+    if !focus.auto_poke {
+        return Ok(None);
+    }
+    let hill_climbability = task.goal.hill_climbability();
+    let min_hill_climbability = focus.min_hill_climbability.min(100);
+    let instruction = if hill_climbability < min_hill_climbability {
+        format!(
+            "goal hill-climbability contract is {hill_climbability}/100, below {min_hill_climbability}. Reframe it with explicit `--metric`, `--baseline`, `--target`, `--guardrail`, and `--verification` fields"
+        )
+    } else {
+        let pending = task
+            .todos
+            .iter()
+            .enumerate()
+            .filter(|(_, todo)| !todo.done)
+            .take(3)
+            .map(|(index, todo)| format!("#{} {}", index + 1, todo.text))
+            .collect::<Vec<_>>();
+        if task.todos.is_empty() {
+            format!(
+                "todo list is empty; decompose the objective with `forgeguard task todo --session {} --add <verifiable-step>`",
+                task.session_id
+            )
+        } else if pending.is_empty() {
+            format!(
+                "all todos are complete; submit executed evidence and model confidence with `forgeguard task ready --session {} --confidence <0-100> --evidence <exact-check-result>`",
+                task.session_id
+            )
+        } else {
+            format!(
+                "{} todo(s) remain: {}. Continue work, then mark completed indexes with `forgeguard task todo --session {} --done <index>`",
+                task.todos.iter().filter(|todo| !todo.done).count(),
+                pending.join("; "),
+                task.session_id
+            )
+        }
+    };
+    continue_auto_poke(root, task, focus, &instruction, true)
+}
+
+fn ready_auto_poke(
+    root: &Path,
+    task: &mut TaskState,
+    focus: &FocusConfig,
+) -> Result<Option<HookDecision>> {
+    if !focus.auto_poke {
+        return Ok(None);
+    }
+    let hill_climbability = task.goal.hill_climbability();
+    let min_hill_climbability = focus.min_hill_climbability.min(100);
+    if hill_climbability < min_hill_climbability {
+        return continue_auto_poke(
+            root,
+            task,
+            focus,
+            &format!(
+                "goal hill-climbability contract is {hill_climbability}/100, below {min_hill_climbability}; reframe the goal contract before completion"
+            ),
+            true,
+        );
+    }
+    let min_confidence = focus.min_confidence.min(100);
+    if task.confidence.unwrap_or(0) < min_confidence {
+        let confidence = task
+            .confidence
+            .map_or_else(|| "unreported".to_owned(), |value| value.to_string());
+        return continue_auto_poke(
+            root,
+            task,
+            focus,
+            &format!(
+                "model confidence is {confidence}/100, below {min_confidence}; inspect concrete uncertainty and submit fresh evidence plus confidence"
+            ),
+            true,
+        );
+    }
+    let limit = focus.max_auto_pokes.min(MAX_AUTO_POKES);
+    if task.auto_pokes >= limit {
+        return Ok(None);
+    }
+    let phase = AUTO_POKE_PHASES[task.auto_pokes as usize];
+    continue_auto_poke(root, task, focus, phase, false)
+}
+
+fn continue_auto_poke(
+    root: &Path,
+    task: &mut TaskState,
+    focus: &FocusConfig,
+    instruction: &str,
+    stop_when_exhausted: bool,
+) -> Result<Option<HookDecision>> {
+    let limit = focus.max_auto_pokes.min(MAX_AUTO_POKES);
+    if task.auto_pokes >= limit {
+        if !stop_when_exhausted {
+            return Ok(None);
+        }
+        let message = format!(
+            "ForgeGuard auto-poke stopped after {limit} continuation request(s): {instruction}. Report the blocker; do not claim completion."
+        );
+        task.status = TaskStatus::Blocked;
+        task.blocker = Some(message.clone());
+        write_task(root, task)?;
+        return Ok(Some(HookDecision::Stop(message)));
+    }
+    task.auto_pokes += 1;
+    task.status = TaskStatus::Active;
+    task.evidence.clear();
+    task.confidence = None;
+    let instruction = truncate(instruction, 700);
+    task.poke_instruction = Some(instruction.clone());
+    task.blocker = None;
+    write_task(root, task)?;
+    Ok(Some(HookDecision::Block(format!(
+        "ForgeGuard auto-poke {current}/{limit}: {instruction}. Continue from exact repository/tool evidence.",
+        current = task.auto_pokes,
+    ))))
+}
+
+fn missing_task_message(session: &str) -> String {
+    format!(
+        "ForgeGuard focus contract missing. Register the exact objective and verifiable todo with `forgeguard task start --session {session} --objective <goal> --todo <step> [--scope <path-prefix>]`, then finish with executed evidence."
+    )
+}
+
+fn incomplete_task_message(session: &str) -> String {
+    format!(
+        "ForgeGuard objective is still active. Inspect remaining work, run verification, then call `forgeguard task ready --session {session} --evidence <exact-check-result>`. Do not invent or silently revise facts, numbers, or completion claims."
+    )
+}
+
+fn task_context(task: &TaskState) -> String {
+    let scopes = if task.scopes.is_empty() {
+        "repository scope not constrained".to_owned()
+    } else {
+        format!("scope prefixes: {}", task.scopes.join(", "))
+    };
+    let semantic = if task.semantic {
+        " Use the host's native goal evaluator when available, but treat executed checks as source of truth."
+    } else {
+        ""
+    };
+    let auto_poke = if task.status == TaskStatus::Active {
+        task.poke_instruction
+            .as_deref()
+            .map(|instruction| {
+                format!(
+                    " Active auto-poke {}: {}.",
+                    task.auto_pokes,
+                    truncate(instruction, 300)
+                )
+            })
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
+    let completed_todos = task.todos.iter().filter(|todo| todo.done).count();
+    let confidence = task
+        .confidence
+        .map_or_else(|| "unreported".to_owned(), |value| format!("{value}/100"));
+    format!(
+        "ForgeGuard objective [{}]: {}. Status: {:?}; {scopes}; hill-climbability contract: {}/100; todos: {completed_todos}/{}; model confidence: {confidence}.{auto_poke} Never state a correction, number, or completion claim without exact tool/check evidence; label it unverified otherwise.{semantic}",
+        task.session_id,
+        truncate(&task.objective, 300),
+        task.status,
+        task.goal.hill_climbability(),
+        task.todos.len()
+    )
+}
+
+fn task_signature(task: Option<&TaskState>) -> String {
+    let mut hasher = DefaultHasher::new();
+    if let Some(task) = task {
+        if let Ok(source) = serde_json::to_vec(task) {
+            hasher.write(&source);
+        }
+    }
+    format!("{:016x}", hasher.finish())
+}
+
+fn session_key(payload: &Value) -> String {
+    let raw = [
+        "session_id",
+        "conversation_id",
+        "conversationId",
+        "transcript_path",
+        "transcriptPath",
+    ]
+    .into_iter()
+    .find_map(|key| payload.get(key).and_then(Value::as_str))
+    .unwrap_or("default");
+    if raw.len() <= 128
+        && !raw.is_empty()
+        && raw
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "-_.".contains(character))
+    {
+        return raw.to_owned();
+    }
+    let hash = raw
+        .as_bytes()
+        .iter()
+        .fold(0xcbf29ce484222325_u64, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+        });
+    format!("session-{hash:016x}")
+}
+
+fn validate_session_id(session_id: &str) -> Result<()> {
+    if session_id.is_empty()
+        || session_id.len() > 128
+        || !session_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "-_.".contains(character))
+    {
+        bail!("session id must contain 1-128 ASCII letters, digits, '-', '_', or '.'");
+    }
+    Ok(())
+}
+
+fn normalize_goal_contract(goal: GoalContract) -> Result<GoalContract> {
+    Ok(GoalContract {
+        metric: normalize_optional_task_item("goal metric", goal.metric)?,
+        baseline: normalize_optional_task_item("goal baseline", goal.baseline)?,
+        target: normalize_optional_task_item("goal target", goal.target)?,
+        guardrails: normalize_task_items("goal guardrail", &goal.guardrails, MAX_TASK_ITEMS)?,
+        verifications: normalize_task_items(
+            "goal verification",
+            &goal.verifications,
+            MAX_TASK_ITEMS,
+        )?,
+    })
+}
+
+fn normalize_optional_task_item(label: &str, value: Option<String>) -> Result<Option<String>> {
+    value
+        .map(|value| {
+            normalize_task_items(label, &[value], 1)
+                .map(|mut values| values.pop().expect("one item"))
+        })
+        .transpose()
+}
+
+fn normalize_task_items(label: &str, items: &[String], max_items: usize) -> Result<Vec<String>> {
+    if items.len() > max_items {
+        bail!("{label} exceeds {max_items} items");
+    }
+    items
+        .iter()
+        .map(|item| {
+            let item = item.trim();
+            if item.is_empty() {
+                bail!("{label} must not be empty");
+            }
+            if item.chars().count() > MAX_TASK_ITEM_CHARS {
+                bail!("{label} exceeds {MAX_TASK_ITEM_CHARS} characters");
+            }
+            Ok(item.to_owned())
+        })
+        .collect()
+}
+
+fn normalize_scope(scope: &str) -> Result<String> {
+    let scope = Path::new(scope.trim());
+    if scope.as_os_str().is_empty() || scope.is_absolute() {
+        bail!("task scope must be a non-empty repository-relative path prefix");
+    }
+    let mut normalized = PathBuf::new();
+    for component in scope.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(value) => normalized.push(value),
+            _ => bail!("task scope must not escape the repository"),
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        return Ok(".".to_owned());
+    }
+    Ok(normalized.to_string_lossy().replace('\\', "/"))
+}
+
+fn normalize_tool_path(root: &Path, path: &str) -> Option<String> {
+    let path = Path::new(path.trim());
+    let relative = if path.is_absolute() {
+        match path.strip_prefix(root) {
+            Ok(relative) => relative,
+            Err(_) => return Some(format!("outside-workspace:{path}", path = path.display())),
+        }
+    } else {
+        path
+    };
+    let mut normalized = PathBuf::new();
+    for component in relative.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(value) => normalized.push(value),
+            _ => return Some(format!("outside-workspace:{}", path.display())),
+        }
+    }
+    (!normalized.as_os_str().is_empty()).then(|| normalized.to_string_lossy().replace('\\', "/"))
+}
+
+fn path_in_scope(path: &str, scope: &str) -> bool {
+    (scope == "." && !path.starts_with("outside-workspace:"))
+        || path == scope
+        || path
+            .strip_prefix(scope)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn collect_tool_paths(value: &Value, key: Option<&str>, paths: &mut Vec<String>) {
+    match value {
+        Value::Object(fields) => {
+            for (key, value) in fields {
+                collect_tool_paths(value, Some(key), paths);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_tool_paths(value, key, paths);
+            }
+        }
+        Value::String(path)
+            if key.is_some_and(|key| {
+                matches!(
+                    key.to_ascii_lowercase().as_str(),
+                    "path"
+                        | "file"
+                        | "files"
+                        | "filepath"
+                        | "file_path"
+                        | "targetfile"
+                        | "target_file"
+                        | "absolutepath"
+                )
+            }) =>
+        {
+            paths.push(path.to_owned());
+        }
+        _ => {}
+    }
+}
+
+fn patch_paths(value: &Value) -> Vec<String> {
+    let Some(command) = value.get("command").and_then(Value::as_str) else {
+        return Vec::new();
+    };
+    command
+        .lines()
+        .filter_map(|line| {
+            ["*** Add File: ", "*** Update File: ", "*** Delete File: "]
+                .into_iter()
+                .find_map(|prefix| line.strip_prefix(prefix))
+                .map(str::to_owned)
+        })
+        .collect()
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_owned();
+    }
+    value.chars().take(max_chars).collect::<String>() + "…"
+}
+
+fn task_path(root: &Path, session: &str) -> PathBuf {
+    root.join(TASK_DIR).join(format!("{session}.json"))
+}
+
+fn read_task(root: &Path, session: &str) -> Result<Option<TaskState>> {
+    let path = task_path(root, session);
+    let source = match fs::read_to_string(&path) {
+        Ok(source) => source,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", path.display()))
+        }
+    };
+    serde_json::from_str(&source)
+        .with_context(|| format!("failed to parse {}", path.display()))
+        .map(Some)
+}
+
+fn write_task(root: &Path, task: &TaskState) -> Result<()> {
+    write_json(&task_path(root, &task.session_id), task)
+}
+
+fn cache_path(root: &Path, session: &str) -> PathBuf {
+    root.join(CACHE_DIR).join(format!("{session}.json"))
+}
+
+fn read_cache(root: &Path, session: &str) -> Option<HookCache> {
+    let source = fs::read_to_string(cache_path(root, session)).ok()?;
     serde_json::from_str(&source).ok()
+}
+
+fn write_cache(root: &Path, session: &str, cache: &HookCache) -> Result<()> {
+    write_json(&cache_path(root, session), cache)
 }
 
 fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -17,6 +17,15 @@ pub(crate) const CODEX_HOOK_COMMAND: &str = "forgeguard hook stop --agent codex"
 pub(crate) const CLAUDE_HOOK_COMMAND: &str = "forgeguard hook stop --agent claude";
 pub(crate) const CURSOR_HOOK_COMMAND: &str = "forgeguard hook stop --agent cursor";
 pub(crate) const ANTIGRAVITY_HOOK_COMMAND: &str = "forgeguard hook stop --agent antigravity";
+pub(crate) const CODEX_CONTEXT_HOOK_COMMAND: &str = "forgeguard hook context --agent codex";
+pub(crate) const CLAUDE_CONTEXT_HOOK_COMMAND: &str = "forgeguard hook context --agent claude";
+pub(crate) const CURSOR_CONTEXT_HOOK_COMMAND: &str = "forgeguard hook context --agent cursor";
+pub(crate) const ANTIGRAVITY_CONTEXT_HOOK_COMMAND: &str =
+    "forgeguard hook context --agent antigravity";
+pub(crate) const CODEX_SCOPE_HOOK_COMMAND: &str = "forgeguard hook scope --agent codex";
+pub(crate) const CLAUDE_SCOPE_HOOK_COMMAND: &str = "forgeguard hook scope --agent claude";
+pub(crate) const CURSOR_SCOPE_HOOK_COMMAND: &str = "forgeguard hook scope --agent cursor";
+pub(crate) const ANTIGRAVITY_SCOPE_HOOK_COMMAND: &str = "forgeguard hook scope --agent antigravity";
 
 const SKILL_ASSETS: &[(&str, &str)] = &[
     (
@@ -329,11 +338,30 @@ fn install_codex(
         written,
         skipped,
     )?;
-    install_grouped_stop_hook(
+    install_grouped_hook(
         root,
         &root.join(".codex/hooks.json"),
+        "Stop",
+        None,
         CODEX_HOOK_COMMAND,
-        true,
+        written,
+        skipped,
+    )?;
+    install_grouped_hook(
+        root,
+        &root.join(".codex/hooks.json"),
+        "SessionStart",
+        Some("startup|resume|compact"),
+        CODEX_CONTEXT_HOOK_COMMAND,
+        written,
+        skipped,
+    )?;
+    install_grouped_hook(
+        root,
+        &root.join(".codex/hooks.json"),
+        "PreToolUse",
+        Some("apply_patch|Edit|Write"),
+        CODEX_SCOPE_HOOK_COMMAND,
         written,
         skipped,
     )
@@ -361,11 +389,30 @@ fn install_claude(
         written,
         skipped,
     )?;
-    install_grouped_stop_hook(
+    install_grouped_hook(
         root,
         &root.join(".claude/settings.json"),
+        "Stop",
+        None,
         CLAUDE_HOOK_COMMAND,
-        false,
+        written,
+        skipped,
+    )?;
+    install_grouped_hook(
+        root,
+        &root.join(".claude/settings.json"),
+        "SessionStart",
+        Some("startup|resume|compact"),
+        CLAUDE_CONTEXT_HOOK_COMMAND,
+        written,
+        skipped,
+    )?;
+    install_grouped_hook(
+        root,
+        &root.join(".claude/settings.json"),
+        "PreToolUse",
+        Some("Edit|Write|MultiEdit|NotebookEdit"),
+        CLAUDE_SCOPE_HOOK_COMMAND,
         written,
         skipped,
     )
@@ -390,7 +437,34 @@ fn install_cursor(
         written,
         skipped,
     )?;
-    install_cursor_stop_hook(root, &root.join(".cursor/hooks.json"), written, skipped)
+    let path = root.join(".cursor/hooks.json");
+    install_cursor_hook(
+        root,
+        &path,
+        "stop",
+        None,
+        CURSOR_HOOK_COMMAND,
+        written,
+        skipped,
+    )?;
+    install_cursor_hook(
+        root,
+        &path,
+        "sessionStart",
+        None,
+        CURSOR_CONTEXT_HOOK_COMMAND,
+        written,
+        skipped,
+    )?;
+    install_cursor_hook(
+        root,
+        &path,
+        "preToolUse",
+        Some("Write|StrReplace|Delete|ApplyPatch"),
+        CURSOR_SCOPE_HOOK_COMMAND,
+        written,
+        skipped,
+    )
 }
 
 fn install_opencode(
@@ -435,7 +509,30 @@ fn install_antigravity(
     };
     write_file(root, &policy_path, AGENTS_TEMPLATE, force, written, skipped)?;
     install_skill(root, skill_directory, force, written, skipped)?;
-    install_antigravity_stop_hook(root, &hook_path, written, skipped)
+    install_antigravity_simple_hook(
+        root,
+        &hook_path,
+        "Stop",
+        ANTIGRAVITY_HOOK_COMMAND,
+        written,
+        skipped,
+    )?;
+    install_antigravity_simple_hook(
+        root,
+        &hook_path,
+        "PreInvocation",
+        ANTIGRAVITY_CONTEXT_HOOK_COMMAND,
+        written,
+        skipped,
+    )?;
+    install_antigravity_tool_hook(
+        root,
+        &hook_path,
+        "write_to_file|replace_file_content|multi_replace_file_content",
+        ANTIGRAVITY_SCOPE_HOOK_COMMAND,
+        written,
+        skipped,
+    )
 }
 
 fn install_skill(
@@ -475,11 +572,12 @@ fn remove_obsolete_skill_assets(root: &Path, directory: &str) -> Result<()> {
     Ok(())
 }
 
-fn install_grouped_stop_hook(
+fn install_grouped_hook(
     root: &Path,
     path: &Path,
+    event: &str,
+    matcher: Option<&str>,
     command: &str,
-    codex: bool,
     written: &mut Vec<String>,
     skipped: &mut Vec<String>,
 ) -> Result<()> {
@@ -489,37 +587,30 @@ fn install_grouped_stop_hook(
         return Ok(());
     }
     let hooks = object_field(&mut document, "hooks", path)?;
-    let stop = array_field(hooks, "Stop", path)?;
-    let handler = if codex {
-        json!({
-            "hooks": [{
-                "type": "command",
-                "command": command,
-                "timeout": 600,
-                "statusMessage": "ForgeGuard verifying changed code"
-            }]
-        })
-    } else {
-        json!({
-            "hooks": [{
-                "type": "command",
-                "command": command,
-                "timeout": 600
-            }]
-        })
-    };
-    stop.push(handler);
+    let command_hook = json!({
+        "type": "command",
+        "command": command,
+        "timeout": if event == "Stop" { 600 } else { 5 }
+    });
+    let mut handler = json!({"hooks": [command_hook]});
+    if let Some(matcher) = matcher {
+        handler["matcher"] = json!(matcher);
+    }
+    array_field(hooks, event, path)?.push(handler);
     write_json_document(root, path, &document, written)
 }
 
-fn install_cursor_stop_hook(
+fn install_cursor_hook(
     root: &Path,
     path: &Path,
+    event: &str,
+    matcher: Option<&str>,
+    command: &str,
     written: &mut Vec<String>,
     skipped: &mut Vec<String>,
 ) -> Result<()> {
     let mut document = read_json_object(path)?;
-    if contains_string(&document, CURSOR_HOOK_COMMAND) {
+    if contains_string(&document, command) {
         record_path(root, path, skipped);
         return Ok(());
     }
@@ -529,21 +620,27 @@ fn install_cursor_stop_hook(
         .entry("version")
         .or_insert(json!(1));
     let hooks = object_field(&mut document, "hooks", path)?;
-    array_field(hooks, "stop", path)?.push(json!({
-        "command": CURSOR_HOOK_COMMAND,
-        "timeout": 600
-    }));
+    let mut handler = json!({
+        "command": command,
+        "timeout": if event == "stop" { 600 } else { 5 }
+    });
+    if let Some(matcher) = matcher {
+        handler["matcher"] = json!(matcher);
+    }
+    array_field(hooks, event, path)?.push(handler);
     write_json_document(root, path, &document, written)
 }
 
-fn install_antigravity_stop_hook(
+fn install_antigravity_simple_hook(
     root: &Path,
     path: &Path,
+    event: &str,
+    command: &str,
     written: &mut Vec<String>,
     skipped: &mut Vec<String>,
 ) -> Result<()> {
     let mut document = read_json_object(path)?;
-    if contains_string(&document, ANTIGRAVITY_HOOK_COMMAND) {
+    if contains_string(&document, command) {
         record_path(root, path, skipped);
         return Ok(());
     }
@@ -557,10 +654,44 @@ fn install_antigravity_stop_hook(
             path.display()
         )
     })?;
-    array_field(hook, "Stop", path)?.push(json!({
+    array_field(hook, event, path)?.push(json!({
         "type": "command",
-        "command": ANTIGRAVITY_HOOK_COMMAND,
-        "timeout": 600
+        "command": command,
+        "timeout": if event == "Stop" { 600 } else { 5 }
+    }));
+    write_json_document(root, path, &document, written)
+}
+
+fn install_antigravity_tool_hook(
+    root: &Path,
+    path: &Path,
+    matcher: &str,
+    command: &str,
+    written: &mut Vec<String>,
+    skipped: &mut Vec<String>,
+) -> Result<()> {
+    let mut document = read_json_object(path)?;
+    if contains_string(&document, command) {
+        record_path(root, path, skipped);
+        return Ok(());
+    }
+    let root_object = document.as_object_mut().expect("validated JSON object");
+    let hook = root_object
+        .entry("forgeguard-quality-gate")
+        .or_insert_with(|| json!({}));
+    let hook = hook.as_object_mut().with_context(|| {
+        format!(
+            "expected `forgeguard-quality-gate` to be an object in {}",
+            path.display()
+        )
+    })?;
+    array_field(hook, "PreToolUse", path)?.push(json!({
+        "matcher": matcher,
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "timeout": 5
+        }]
     }));
     write_json_document(root, path, &document, written)
 }

--- a/crates/forgeguard-core/src/lib.rs
+++ b/crates/forgeguard-core/src/lib.rs
@@ -14,12 +14,15 @@ pub mod scanner;
 pub mod update;
 
 pub use baseline::{create_baseline, Baseline, BaselineEntry, BASELINE_FILE};
-pub use config::{CommandConfig, ForgeGuardConfig, GuardMode};
+pub use config::{CommandConfig, FocusConfig, ForgeGuardConfig, GuardMode};
 pub use detector::{detect_project, ProjectDetection};
 pub use doctor::{run_doctor, DoctorReport};
 pub use gate::{run_gate, GateOptions};
 pub use hook::{
-    evaluate_stop_hook, ignore_forgeguard_artifacts, render_hook_decision, HookAgent, HookDecision,
+    evaluate_context_hook, evaluate_scope_hook, evaluate_stop_hook, ignore_forgeguard_artifacts,
+    mark_task_ready, mark_task_ready_with_confidence, render_context_hook, render_hook_decision,
+    render_scope_warning, start_task, start_task_with_contract, task_state, update_task_todos,
+    GoalContract, HookAgent, HookDecision, TaskState, TaskStatus, TaskTodo,
 };
 pub use init::{
     initialize_global, initialize_project, AgentTarget, GlobalInitReport, InitOptions, InitReport,

--- a/crates/forgeguard-core/tests/config_test.rs
+++ b/crates/forgeguard-core/tests/config_test.rs
@@ -28,6 +28,13 @@ fn configuration_round_trips_through_toml() {
 fn new_configuration_defaults_to_default_mode() {
     let config = ForgeGuardConfig::new("example", Vec::new());
     assert_eq!(config.mode, GuardMode::Default);
+    assert!(config.focus.enabled);
+    assert_eq!(config.focus.max_retries, 3);
+    assert_eq!(config.focus.no_progress_limit, 2);
+    assert!(config.focus.auto_poke);
+    assert_eq!(config.focus.max_auto_pokes, 3);
+    assert_eq!(config.focus.min_confidence, 80);
+    assert_eq!(config.focus.min_hill_climbability, 80);
 }
 
 #[test]
@@ -54,6 +61,8 @@ duplicate_block_lines = 6
 
     let config = ForgeGuardConfig::load(directory.path()).expect("load legacy config");
     assert_eq!(config.mode, GuardMode::Strict);
+    assert!(config.focus.enabled);
+    assert!(config.focus.auto_poke);
 }
 
 #[test]

--- a/crates/forgeguard-core/tests/hook_test.rs
+++ b/crates/forgeguard-core/tests/hook_test.rs
@@ -1,16 +1,20 @@
 use std::{fs, process::Command};
 
 use forgeguard_core::{
-    evaluate_stop_hook, render_hook_decision, ForgeGuardConfig, HookAgent, HookDecision,
+    evaluate_context_hook, evaluate_scope_hook, evaluate_stop_hook, mark_task_ready,
+    mark_task_ready_with_confidence, render_hook_decision, start_task, start_task_with_contract,
+    task_state, update_task_todos, ForgeGuardConfig, GoalContract, HookAgent, HookDecision,
+    TaskStatus,
 };
 use tempfile::tempdir;
 
 #[test]
-fn blocked_hook_is_compact_cached_and_loop_safe() {
+fn blocked_hook_is_compact_cached_and_bounded() {
     let directory = tempdir().expect("temp directory");
     git_init(directory.path());
     let mut config = ForgeGuardConfig::new("sample", Vec::new());
     config.mode = forgeguard_core::GuardMode::Strict;
+    config.focus.auto_poke = false;
     config.save(directory.path()).expect("save config");
     for index in 0..40 {
         fs::write(
@@ -49,7 +53,7 @@ fn blocked_hook_is_compact_cached_and_loop_safe() {
     );
     let (decision, cache_hit) =
         evaluate_stop_hook(directory.path(), &repeated).expect("evaluate repeated hook");
-    assert_eq!(decision, HookDecision::Pass);
+    assert!(matches!(decision, HookDecision::Stop(_)));
     assert!(cache_hit);
 
     let antigravity_repeated = format!(
@@ -58,7 +62,7 @@ fn blocked_hook_is_compact_cached_and_loop_safe() {
     );
     let (decision, cache_hit) = evaluate_stop_hook(directory.path(), &antigravity_repeated)
         .expect("evaluate repeated Antigravity hook");
-    assert_eq!(decision, HookDecision::Pass);
+    assert!(matches!(decision, HookDecision::Stop(_)));
     assert!(cache_hit);
 }
 
@@ -104,13 +108,413 @@ fn agent_protocols_are_silent_or_structured() {
     );
     assert_eq!(
         serde_json::from_str::<serde_json::Value>(&codex).expect("Codex JSON")["systemMessage"],
-        "Fix failing tests"
+        serde_json::Value::Null
+    );
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&codex).expect("Codex JSON")["decision"],
+        "block"
     );
     assert_eq!(
         serde_json::from_str::<serde_json::Value>(&antigravity).expect("Antigravity JSON")
             ["decision"],
         "continue"
     );
+
+    let codex_stop = render_hook_decision(
+        HookAgent::Codex,
+        &HookDecision::Stop("No progress".to_owned()),
+    );
+    let codex_stop: serde_json::Value = serde_json::from_str(&codex_stop).expect("Codex stop JSON");
+    assert_eq!(codex_stop["continue"], false);
+    assert_eq!(codex_stop["stopReason"], "No progress");
+}
+
+#[test]
+fn task_state_blocks_early_stop_then_completes_with_evidence() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = forgeguard_core::GuardMode::Strict;
+    config.focus.auto_poke = false;
+    config.save(directory.path()).expect("save config");
+    fs::write(
+        directory.path().join("service.ts"),
+        "export const value = 1;\n",
+    )
+    .expect("write source");
+    start_task(
+        directory.path(),
+        "session-1",
+        "Add the service value and verify it",
+        &["service.ts".to_owned()],
+        false,
+    )
+    .expect("start task");
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"session-1"}}"#,
+        directory.path().display()
+    );
+
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("early stop");
+    assert!(matches!(decision, HookDecision::Block(_)));
+
+    mark_task_ready(
+        directory.path(),
+        "session-1",
+        &["forgeguard gate passed".to_owned()],
+    )
+    .expect("mark ready");
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("completed stop");
+    assert_eq!(decision, HookDecision::Pass);
+    assert_eq!(
+        task_state(directory.path(), "session-1")
+            .expect("read task")
+            .expect("task")
+            .status,
+        TaskStatus::Completed
+    );
+}
+
+#[test]
+fn auto_poke_runs_bounded_evidence_phases_before_completion() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = forgeguard_core::GuardMode::Strict;
+    config.focus.auto_poke = true;
+    config.focus.max_auto_pokes = 99;
+    config.save(directory.path()).expect("save config");
+    start_task_with_contract(
+        directory.path(),
+        "session-poke",
+        "Finish implementation, tests, and review",
+        &[],
+        false,
+        GoalContract {
+            metric: Some("verified completion checks".to_owned()),
+            baseline: Some("implementation incomplete".to_owned()),
+            target: Some("all checks pass".to_owned()),
+            guardrails: vec!["no regression".to_owned()],
+            verifications: vec!["cargo test".to_owned()],
+        },
+        &["implement requested behavior".to_owned()],
+    )
+    .expect("start task");
+    update_task_todos(directory.path(), "session-poke", &[], &[1]).expect("complete todo");
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"session-poke"}}"#,
+        directory.path().display()
+    );
+    let phases = [
+        "remaining TODOs",
+        "relevant tests and checks",
+        "review the full diff",
+        "verify contracts",
+        "final verification",
+    ];
+
+    for (index, phase) in phases.into_iter().enumerate() {
+        mark_task_ready_with_confidence(
+            directory.path(),
+            "session-poke",
+            &[format!("phase {} evidence", index + 1)],
+            Some(100),
+        )
+        .expect("mark phase ready");
+        let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("auto-poke stop");
+        let HookDecision::Block(message) = decision else {
+            panic!("expected auto-poke block");
+        };
+        assert!(message.contains(&format!("auto-poke {}/5", index + 1)));
+        assert!(message.contains(phase));
+        let task = task_state(directory.path(), "session-poke")
+            .expect("read task")
+            .expect("task");
+        assert_eq!(task.status, TaskStatus::Active);
+        assert_eq!(task.auto_pokes, (index + 1) as u32);
+        assert!(task.evidence.is_empty());
+        let context = evaluate_context_hook(directory.path(), &input, HookAgent::Codex)
+            .expect("evaluate auto-poke context")
+            .expect("auto-poke context");
+        assert!(context.contains(phase));
+    }
+
+    mark_task_ready_with_confidence(
+        directory.path(),
+        "session-poke",
+        &["final gate passed".to_owned()],
+        Some(100),
+    )
+    .expect("mark final ready");
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("final stop");
+    assert_eq!(decision, HookDecision::Pass);
+    assert_eq!(
+        task_state(directory.path(), "session-poke")
+            .expect("read task")
+            .expect("task")
+            .status,
+        TaskStatus::Completed
+    );
+}
+
+#[test]
+fn auto_poke_uses_hill_goal_todos_and_confidence_before_completion() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = forgeguard_core::GuardMode::Strict;
+    config.focus.auto_poke = true;
+    config.focus.max_auto_pokes = 5;
+    config.save(directory.path()).expect("save config");
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"session-state"}}"#,
+        directory.path().display()
+    );
+
+    start_task(
+        directory.path(),
+        "session-state",
+        "Improve performance",
+        &[],
+        false,
+    )
+    .expect("start abstract task");
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("abstract stop");
+    let HookDecision::Block(message) = decision else {
+        panic!("abstract goal must continue");
+    };
+    assert!(message.contains("hill-climbability contract is 0/100"));
+
+    let goal = GoalContract {
+        metric: Some("p95 latency /search".to_owned()),
+        baseline: Some("900 ms".to_owned()),
+        target: Some("below 300 ms".to_owned()),
+        guardrails: vec!["error rate does not increase".to_owned()],
+        verifications: vec!["regression tests pass".to_owned()],
+    };
+    assert_eq!(goal.hill_climbability(), 100);
+    start_task_with_contract(
+        directory.path(),
+        "session-state",
+        "Reduce /search p95 latency without regressions",
+        &[],
+        false,
+        goal,
+        &[
+            "measure baseline".to_owned(),
+            "optimize endpoint".to_owned(),
+        ],
+    )
+    .expect("reframe task");
+    assert_eq!(
+        task_state(directory.path(), "session-state")
+            .expect("read reframed task")
+            .expect("reframed task")
+            .auto_pokes,
+        1
+    );
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("todo stop");
+    let HookDecision::Block(message) = decision else {
+        panic!("pending todos must continue");
+    };
+    assert!(message.contains("2 todo(s) remain"));
+
+    update_task_todos(directory.path(), "session-state", &[], &[1]).expect("complete first todo");
+    assert!(mark_task_ready(directory.path(), "session-state", &["partial".to_owned()]).is_err());
+    update_task_todos(directory.path(), "session-state", &[], &[2]).expect("complete second todo");
+    mark_task_ready_with_confidence(
+        directory.path(),
+        "session-state",
+        &["tests passed".to_owned()],
+        Some(50),
+    )
+    .expect("mark low-confidence ready");
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("confidence stop");
+    let HookDecision::Block(message) = decision else {
+        panic!("low confidence must continue");
+    };
+    assert!(message.contains("confidence is 50/100"));
+    let task = task_state(directory.path(), "session-state")
+        .expect("read task")
+        .expect("task");
+    assert_eq!(task.confidence_history, vec![50]);
+    assert_eq!(task.confidence, None);
+    assert!(mark_task_ready_with_confidence(
+        directory.path(),
+        "session-state",
+        &["invalid confidence".to_owned()],
+        Some(101),
+    )
+    .is_err());
+
+    for confidence in [60, 70] {
+        mark_task_ready_with_confidence(
+            directory.path(),
+            "session-state",
+            &["more evidence".to_owned()],
+            Some(confidence),
+        )
+        .expect("mark still-low confidence");
+        let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("bounded poke");
+        assert!(matches!(decision, HookDecision::Block(_)));
+    }
+    mark_task_ready_with_confidence(
+        directory.path(),
+        "session-state",
+        &["confidence remains low".to_owned()],
+        Some(70),
+    )
+    .expect("mark exhausted confidence");
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("exhausted poke");
+    assert!(matches!(decision, HookDecision::Stop(_)));
+    assert_eq!(
+        task_state(directory.path(), "session-state")
+            .expect("read blocked task")
+            .expect("blocked task")
+            .status,
+        TaskStatus::Blocked
+    );
+}
+
+#[test]
+fn task_context_is_session_scoped_and_scope_drift_is_warned() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    start_task(
+        directory.path(),
+        "session-a",
+        "Change only core source",
+        &["src".to_owned()],
+        true,
+    )
+    .expect("start task");
+    let context_input = format!(
+        r#"{{"cwd":"{}","session_id":"session-a","hook_event_name":"SessionStart"}}"#,
+        directory.path().display()
+    );
+    let context = evaluate_context_hook(directory.path(), &context_input, HookAgent::Codex)
+        .expect("evaluate context")
+        .expect("context");
+    assert!(context.contains("Change only core source"));
+    assert!(context.contains("native goal evaluator"));
+
+    let outside = format!(
+        r#"{{"cwd":"{}","session_id":"session-a","tool_input":{{"file_path":"tests/api.rs"}}}}"#,
+        directory.path().display()
+    );
+    let warning = evaluate_scope_hook(directory.path(), &outside)
+        .expect("evaluate scope")
+        .expect("scope warning");
+    assert!(warning.contains("tests/api.rs"));
+
+    let inside = format!(
+        r#"{{"cwd":"{}","session_id":"session-a","tool_input":{{"file_path":"src/api.rs"}}}}"#,
+        directory.path().display()
+    );
+    assert!(evaluate_scope_hook(directory.path(), &inside)
+        .expect("evaluate scope")
+        .is_none());
+    assert!(task_state(directory.path(), "session-b")
+        .expect("read other session")
+        .is_none());
+
+    let later_invocation = format!(
+        r#"{{"workspacePaths":["{}"],"conversationId":"new-session","invocationNum":1}}"#,
+        directory.path().display()
+    );
+    assert!(
+        evaluate_context_hook(directory.path(), &later_invocation, HookAgent::Antigravity)
+            .expect("evaluate later Antigravity invocation")
+            .is_none()
+    );
+}
+
+#[test]
+fn stop_retry_budget_is_isolated_by_session() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = forgeguard_core::GuardMode::Strict;
+    config.save(directory.path()).expect("save config");
+    fs::write(
+        directory.path().join("service.ts"),
+        "for (const user of users) { await db.query('SELECT id FROM users'); }\n",
+    )
+    .expect("write source");
+    let input = |session: &str| {
+        format!(
+            r#"{{"cwd":"{}","session_id":"{session}"}}"#,
+            directory.path().display()
+        )
+    };
+
+    let (first_a, _) =
+        evaluate_stop_hook(directory.path(), &input("session-a")).expect("first session-a stop");
+    assert!(matches!(first_a, HookDecision::Block(_)));
+    let (second_a, _) =
+        evaluate_stop_hook(directory.path(), &input("session-a")).expect("second session-a stop");
+    assert!(matches!(second_a, HookDecision::Block(_)));
+    let (first_b, _) =
+        evaluate_stop_hook(directory.path(), &input("session-b")).expect("first session-b stop");
+    let HookDecision::Block(message) = first_b else {
+        panic!("session-b must start with a fresh retry budget");
+    };
+    assert!(message.contains("attempt 1/3"));
+}
+
+#[test]
+fn cursor_transcript_path_isolates_retry_budget_without_a_session_id() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = forgeguard_core::GuardMode::Strict;
+    config.save(directory.path()).expect("save config");
+    fs::write(
+        directory.path().join("service.ts"),
+        "for (const user of users) { await db.query('SELECT id FROM users'); }\n",
+    )
+    .expect("write source");
+    let input = |transcript: &str| {
+        format!(
+            r#"{{"cwd":"{}","transcript_path":"{transcript}"}}"#,
+            directory.path().display()
+        )
+    };
+
+    evaluate_stop_hook(directory.path(), &input("/tmp/cursor-a.jsonl"))
+        .expect("first cursor-a stop");
+    evaluate_stop_hook(directory.path(), &input("/tmp/cursor-a.jsonl"))
+        .expect("second cursor-a stop");
+    let (first_b, _) = evaluate_stop_hook(directory.path(), &input("/tmp/cursor-b.jsonl"))
+        .expect("first cursor-b stop");
+    let HookDecision::Block(message) = first_b else {
+        panic!("cursor-b must start with a fresh retry budget");
+    };
+    assert!(message.contains("attempt 1/3"));
+}
+
+#[test]
+fn task_contract_rejects_untrusted_paths_and_unsupported_evidence() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    assert!(start_task(directory.path(), "../escape", "Unsafe session", &[], false,).is_err());
+    assert!(start_task(
+        directory.path(),
+        "safe-session",
+        "Unsafe scope",
+        &["../outside".to_owned()],
+        false,
+    )
+    .is_err());
+    start_task(
+        directory.path(),
+        "safe-session",
+        "Valid task",
+        &["src".to_owned()],
+        false,
+    )
+    .expect("start valid task");
+    assert!(mark_task_ready(directory.path(), "safe-session", &[]).is_err());
 }
 
 #[test]

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -22,6 +22,12 @@ fn installs_configuration_for_all_supported_agents() {
     .expect("initialize project");
 
     assert!(directory.path().join(".forgeguard/config.toml").exists());
+    assert!(
+        forgeguard_core::ForgeGuardConfig::load(directory.path())
+            .expect("load initialized config")
+            .focus
+            .auto_poke
+    );
     assert!(directory.path().join("AGENTS.md").exists());
     assert!(directory.path().join("CLAUDE.md").exists());
     assert!(directory
@@ -72,6 +78,24 @@ fn installs_configuration_for_all_supported_agents() {
     assert!(algorithm_policy.contains("actual bottleneck before optimizing"));
     let doctor = forgeguard_core::run_doctor(directory.path(), None).expect("run doctor");
     assert!(doctor.hooks.iter().all(|hook| hook.configured));
+    let codex_hooks: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(directory.path().join(".codex/hooks.json")).expect("read Codex hooks"),
+    )
+    .expect("parse Codex hooks");
+    assert_eq!(
+        codex_hooks["hooks"]["Stop"].as_array().map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        codex_hooks["hooks"]["SessionStart"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        codex_hooks["hooks"]["PreToolUse"].as_array().map(Vec::len),
+        Some(1)
+    );
     assert!(!report.files_written.is_empty());
 }
 
@@ -188,6 +212,18 @@ fn hook_install_preserves_existing_settings_and_is_idempotent() {
     assert_eq!(
         source
             .matches("forgeguard hook stop --agent claude")
+            .count(),
+        1
+    );
+    assert_eq!(
+        source
+            .matches("forgeguard hook context --agent claude")
+            .count(),
+        1
+    );
+    assert_eq!(
+        source
+            .matches("forgeguard hook scope --agent claude")
             .count(),
         1
     );
@@ -333,6 +369,18 @@ fn antigravity_hook_merge_is_idempotent() {
     assert_eq!(
         source
             .matches("forgeguard hook stop --agent antigravity")
+            .count(),
+        1
+    );
+    assert_eq!(
+        source
+            .matches("forgeguard hook context --agent antigravity")
+            .count(),
+        1
+    );
+    assert_eq!(
+        source
+            .matches("forgeguard hook scope --agent antigravity")
             .count(),
         1
     );

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,7 @@ Rules, skills, hooks, and configured repository commands are language-agnostic. 
 request
   → project detection
   → compact rule + conditional skill
+  → session-scoped objective and path prefixes
   → implementation cycle
   → Stop hook
   → changed-source scanning
@@ -22,7 +23,7 @@ request
   → silent pass or bounded agent feedback
 ```
 
-Full reports stay local under `.forgeguard/reports/`; hook cache lives under `.forgeguard/cache/`. Both paths are excluded from worktree fingerprints. Cache lookup is `O(1)` after an `O(total changed bytes)` streaming fingerprint and prevents unchanged gates from rerunning.
+Full reports stay local under `.forgeguard/reports/`; per-session task and hook state live under `.forgeguard/cache/`. Both paths are excluded from worktree fingerprints. Cache lookup is `O(1)` after an `O(total changed bytes)` streaming fingerprint and prevents unchanged gates from rerunning.
 
 ## Token contract
 
@@ -52,8 +53,13 @@ Source walking honors Git ignore files and excludes generated or dependency dire
 
 - Hooks merge into existing JSON without replacing unrelated settings.
 - Global hooks pass silently outside initialized repositories.
-- Claude returns `decision: block`; Cursor returns `followup_message`; Codex surfaces a deterministic `systemMessage`; Antigravity returns `decision: continue`.
-- Repeated blocked stops with an unchanged fingerprint pass once to prevent infinite loops.
+- Claude and Codex return `decision: block`; Cursor returns `followup_message`; Antigravity returns `decision: continue`.
+- Session start/resume/compaction hooks restore the active objective where the host protocol supports context injection; Antigravity injects it on the first model invocation of an execution.
+- Pre-tool hooks warn when an edit path falls outside explicitly declared repository-relative prefixes. ForgeGuard never infers scope from prompt text.
+- Blocked stops use per-session retry and no-progress limits. Exhaustion stops with an explicit blocker instead of claiming completion or looping forever.
+- Default-on auto-poke returns the host agent to incomplete todos, low-confidence evidence, or fixed TODO/test/review/contract/final-verification phases. The same Stop-hook protocol works in headless mode where the host executes lifecycle hooks; each continuation is a new model request, and the hard limit is five. Configuration can explicitly opt out.
+- Hill-climbability is computed without an LLM from five explicit goal-contract fields: metric, baseline, target, guardrail, and verification. Missing fields trigger reframing instead of speculative prose scoring.
+- Deterministic focus state uses no LLM calls. Semantic evaluation is opt-in and delegated to native host goal mode; executed checks remain authoritative.
 - Agent hook trust remains controlled by each host application.
 - OpenCode uses the shared `AGENTS.md` and Agent Skill standards. Its current lifecycle cannot reliably prevent the loop from stopping, so ForgeGuard does not install a misleading pseudo-blocking hook.
 

--- a/docs/FOCUS.md
+++ b/docs/FOCUS.md
@@ -1,0 +1,121 @@
+# Focus, auto-poke, and hill-climbability
+
+ForgeGuard installs focus enforcement with `forgeguard init`. No extra configuration is required for new repositories. Auto-poke is enabled by default and remains bounded.
+
+## Lifecycle hooks
+
+ForgeGuard uses three hooks where the host supports them:
+
+- `SessionStart` restores the session objective and active continuation after startup, resume, or compaction.
+- `PreToolUse` warns when an explicit edit path falls outside declared scope.
+- `Stop` checks task state, repository gates, evidence, and continuation limits.
+
+Auto-poke itself is implemented by the `Stop` hook. A block response makes the host submit a new model request with the next instruction. Headless operation uses the same path when the host executes lifecycle hooks in headless mode.
+
+OpenCode receives the shared policy and skill, but ForgeGuard does not claim automatic continuation there because its lifecycle does not expose a reliable blocking Stop hook.
+
+## Session state
+
+Each host conversation gets a separate task file under `.forgeguard/cache/tasks/`. State contains:
+
+- exact objective and repository-relative scope prefixes;
+- metric, baseline, target, guardrails, and verification contract;
+- ordered todos and completion status;
+- advisory model-confidence history;
+- evidence, current status, auto-poke count, and blocker.
+
+Task and Stop caches are excluded from worktree fingerprints and version control.
+
+## Continuation flow
+
+```text
+model ends turn
+  → Stop hook reads session task
+  → abstract goal: request measurable contract
+  → incomplete todos: continue next todo
+  → todos complete: require evidence and confidence
+  → gate failure: continue from exact failure
+  → gate pass: TODO/test/review/contract/final verification poke
+  → limits reached: stop with blocker
+  → requirements satisfied: allow completion
+```
+
+Every continuation is a new host request. Generated configuration allows three auto-pokes. ForgeGuard clamps any configured value to a hard maximum of five. Retry and no-progress budgets separately bound unchanged failures.
+
+## Hill-climbability contract
+
+ForgeGuard does not infer whether prose sounds measurable. It scores explicit contract completeness:
+
+- metric: 20 points;
+- baseline: 20 points;
+- target: 20 points;
+- at least one guardrail: 20 points;
+- at least one verification method: 20 points.
+
+The score measures contract completeness, not semantic quality. A 100/100 contract can still contain a bad metric; executed evidence and repository gates remain authoritative.
+
+Bad objective:
+
+```text
+Improve application performance.
+```
+
+Hill-climbable objective:
+
+```text
+Reduce p95 latency for /search from 900 ms to below 300 ms,
+without increasing error rate, with all regression tests passing.
+```
+
+Register it:
+
+```bash
+forgeguard task start --session "$SESSION" \
+  --objective "Reduce /search latency without regressions" \
+  --metric "p95 latency /search" \
+  --baseline "900 ms" \
+  --target "below 300 ms" \
+  --guardrail "error rate does not increase" \
+  --verification "regression tests pass" \
+  --todo "measure baseline" \
+  --todo "optimize endpoint"
+```
+
+Update and finish:
+
+```bash
+forgeguard task todo --session "$SESSION" --done 1
+forgeguard task ready --session "$SESSION" \
+  --confidence 90 \
+  --evidence "benchmark: p95 284 ms; error rate unchanged"
+```
+
+Confidence is model-reported and advisory. It never replaces tool output, tests, benchmarks, or the ForgeGuard gate.
+
+## Configuration
+
+Fresh initialization writes:
+
+```toml
+[focus]
+enabled = true
+max_retries = 3
+no_progress_limit = 2
+auto_poke = true
+max_auto_pokes = 3
+min_confidence = 80
+min_hill_climbability = 80
+```
+
+No edit is required. Set `auto_poke = false` only to opt out, or lower `max_auto_pokes` when request cost matters more than persistence.
+
+## Upgrading an initialized repository
+
+Upgrade the binary, then refresh bundled policies, skills, and hook entries:
+
+```bash
+forgeguard init --agent all --force
+forgeguard doctor
+```
+
+`--force` regenerates `.forgeguard/config.toml`. Back up custom commands or modes first, then reapply them after refresh. Existing committed baselines are preserved.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,21 +15,19 @@
 - Conservative N+1 and query-in-loop detection.
 - Consolidated cross-agent engineering skill and current Codex skill layout.
 
-## Next
-
-- Function-level data-flow and complexity analysis.
-- SARIF output and baseline support.
-
-## 0.3 — Agent enforcement
+## 0.3–0.7 — Agent enforcement and persistence
 
 - Claude Code, Codex, Cursor, and Antigravity Stop hooks.
 - Silent-success and bounded-failure token protocol.
 - Changed-worktree cache and local full reports.
 - Command timeout and hook installation diagnostics.
+- Session-scoped objectives, todo/confidence state, deterministic hill-climbability, bounded retry/no-progress handling, context restoration, declared-scope warnings, and default-on auto-poke verification phases.
 - Cross-platform release binaries and checksum-verifying installers.
 
-## 0.4 — Database and AI packs
+## Next — Database and AI packs
 
+- Function-level data-flow and complexity analysis.
+- SARIF output.
 - MCP schema verification.
 - Query-plan evidence collection.
 - AI tool schema, agent-loop, RAG, token, and evaluation gates.

--- a/examples/forgeguard.toml
+++ b/examples/forgeguard.toml
@@ -11,6 +11,15 @@ include_tests = false
 extra_excludes = ["generated/"]
 duplicate_block_lines = 6
 
+[focus]
+enabled = true
+max_retries = 3
+no_progress_limit = 2
+auto_poke = true
+max_auto_pokes = 3
+min_confidence = 80
+min_hill_climbability = 80
+
 [[commands]]
 name = "format"
 command = "cargo fmt --all -- --check"


### PR DESCRIPTION
## What changed

- add per-session objective, todo, confidence, evidence, and bounded retry state
- add default-on auto-poke continuation across Stop hooks
- restore objective after resume/compaction and warn on explicit scope drift
- add deterministic hill-climbability contracts and task CLI commands
- fix Codex Stop hook blocking protocol and add cross-agent contract tests
- document focus lifecycle, token bounds, headless behavior, and upgrades
- bump workspace version to 0.7.0

## Why

Agents could stop early, lose direction after compaction, repeat unsupported claims, or loop without a hard continuation budget. This adds harness-level persistence while keeping evidence deterministic and request usage bounded.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace (82 passed)
- cargo build --locked --workspace --release
- sh -n install.sh
- sh tests/install_test.sh
- forgeguard gate --changed --output compact (0 errors, 0 warnings, 0 failed checks)
