### PR TITLE
Harden enforcement and semantic evidence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,22 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.78.0
-      - run: cargo check --workspace
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@788abdaa468b02b2d53a3d1d8fcac62dc9858f4a # 1.78.0
+      - run: cargo check --locked --workspace
 
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-      - run: cargo test --workspace
-      - run: cargo build --workspace --release
+      - run: cargo test --locked --workspace
+      - run: cargo build --locked --workspace --release
       - run: sh -n install.sh
       - run: sh tests/install_test.sh
       - name: Parse PowerShell installer
@@ -44,3 +44,13 @@ jobs:
             $errors | ForEach-Object { Write-Error $_ }
             exit 1
           }
+
+  supply-chain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - run: cargo install --locked cargo-deny --version 0.20.2
+      - run: cargo install --locked cargo-audit --version 0.22.2
+      - run: cargo deny check
+      - run: cargo audit --deny warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,24 +5,28 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   verify:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Verify tag matches package version
         shell: bash
         run: |
           package_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
           test "${GITHUB_REF_NAME#v}" = "$package_version"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           components: rustfmt, clippy
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - run: cargo test --locked --workspace
+      - run: cargo install --locked cargo-deny --version 0.20.2
+      - run: cargo install --locked cargo-audit --version 0.22.2
+      - run: cargo deny check
+      - run: cargo audit --deny warnings
       - run: sh -n install.sh
       - run: sh tests/install_test.sh
       - name: Parse PowerShell installer
@@ -73,8 +77,8 @@ jobs:
             archive: zip
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.target }}
       - run: cargo build --locked --release --target ${{ matrix.target }}
@@ -99,7 +103,7 @@ jobs:
           Compress-Archive -Path dist/package/forgeguard.exe -DestinationPath "dist/${{ matrix.asset }}"
           (Get-FileHash -Algorithm SHA256 "dist/${{ matrix.asset }}").Hash.ToLowerInvariant() |
             Set-Content -NoNewline "dist/${{ matrix.asset }}.sha256"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.asset }}
           path: |
@@ -110,12 +114,14 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           merge-multiple: true
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           files: dist/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ inspect → design → implement → test → review → verify
 
 ForgeGuard pushes generated code toward the discipline expected from a top-tier software engineering team: correct boundaries, reusable behavior, efficient algorithms and queries, explicit failure handling, focused tests, reviewed diffs, and claims backed by executed evidence.
 
-Universal rules, skills, hooks, and repository commands work with any language. Deep structural rules use Tree-sitter for JavaScript, TypeScript, TSX, Rust, Go, Python, Java, Kotlin, C#, C, C++, Ruby, PHP, Swift, Dart, and Shell. Every language still receives workflow enforcement and configured quality commands; common non-parser source types also receive exact duplicate checks. Findings remain review evidence, not a substitute for tests, profilers, or query plans.
+Workflow supervision and configured repository commands work with any language. Parser, structural-rule, and semantic-pack coverage are separate capabilities: Tree-sitter supplies syntax evidence across the listed profiles, while bounded import/binding and local-wrapper provenance is currently available for JavaScript/TypeScript, Python, Rust, and Go. Run `forgeguard capabilities` for the exact matrix. ForgeGuard is an AST-assisted quality scanner, not a whole-program semantic analyzer; findings remain review evidence, not a substitute for compilers, tests, profilers, or query plans.
 
 ## Why ForgeGuard
 
@@ -56,7 +56,8 @@ A blocked gate may cause the host agent to use another turn to fix real failures
 
 - Rust single-binary CLI.
 - Lightweight source detection across common backend, frontend, mobile, systems, data, script, and infrastructure languages.
-- AST-backed loop and call-site analysis for 16 common language profiles.
+- AST-backed loop and call-site analysis across the published parser capability matrix.
+- Bounded database/network provenance packs for JavaScript/TypeScript, Python, Rust, and Go.
 - Codex `AGENTS.md` plus project skills.
 - Claude Code `CLAUDE.md` plus project skills.
 - Cursor always-on rule plus shared project skills.
@@ -70,7 +71,7 @@ A blocked gate may cause the host agent to use another turn to fix real failures
 - `default`, `lite`, and `strict` operating modes with project and global persistence.
 - Committed finding baselines for adopting strict gates without accepting new debt.
 - Interactive mode selection during `forgeguard init` and via `forgeguard mode`.
-- Human-readable and JSON reports.
+- Human-readable, JSON, and SARIF 2.1.0 reports.
 
 ## Install
 
@@ -198,6 +199,7 @@ Produce machine-readable output:
 
 ```bash
 forgeguard gate --json
+forgeguard review --output sarif > forgeguard.sarif
 ```
 
 Produce bounded agent-facing output:
@@ -268,7 +270,7 @@ Other agents receive the universal CLI gate immediately. Agents that understand 
 Example:
 
 ```toml
-version = 1
+version = 2
 mode = "default"
 
 [project]
@@ -280,6 +282,14 @@ max_file_bytes = 1000000
 include_tests = false
 extra_excludes = ["generated/"]
 duplicate_block_lines = 6
+
+[policies]
+warnings_block = false
+
+[rules.FG-NET-001]
+enabled = true
+severity = "warning"
+block = true
 
 [focus]
 enabled = true
@@ -308,11 +318,13 @@ timeout_seconds = 600
 
 ForgeGuard supports three operating modes:
 
-- `default`: token-friendly default for new installs. Static findings are reported, but only failed required commands block.
+- `default`: failed required commands block; static findings block only when a rule sets `block = true`.
 - `lite`: report-only mode for baselining or cleanup work. Static findings do not block.
-- `strict`: strong guard mode. Failed required commands and error-level deterministic findings block.
+- `strict`: failed required commands plus Warning- and Error-level static findings block. Info remains evidence.
 
-Older configs with `mode = "guard"` still load as `strict` for compatibility.
+Version 1 configs preserve the old Strict behavior that blocks only Error findings. Run `forgeguard config migrate` to opt into version 2 policy; older `mode = "guard"` values still load as `strict`.
+
+Per-rule `enabled`, `severity`, and `block` override global policy. `Lite` always keeps static findings nonblocking. Required command failures block in every mode.
 
 Focus state and scope checks are local and make no LLM calls. `max_retries` bounds corrective turns; `no_progress_limit` stops a session that produces no repository or task-state progress. `auto_poke` is enabled automatically by `forgeguard init`; each continuation creates a new host request and consumes model tokens, so `max_auto_pokes` defaults to three and has a hard cap of five. Set `auto_poke = false` only when manually opting out. Pending todos, confidence below `min_confidence`, or goal-contract completeness below `min_hill_climbability` keep the task active. Hill-climbability is a deterministic 0–100 completeness score: metric, baseline, target, guardrail, and verification contribute 20 points each. ForgeGuard does not guess these fields from prose. `forgeguard task start --semantic` only asks a supported host to use its native goal evaluator.
 
@@ -359,8 +371,10 @@ When run in a terminal without an explicit mode, `forgeguard mode` opens the sam
 |---|---|
 | `forgeguard init` | Install project configuration and agent skills. Use `--global` for user-level skills. |
 | `forgeguard detect` | Detect languages, frameworks, database tools, tests, and commands. |
+| `forgeguard capabilities` | Show workflow, parser, structural-rule, and semantic-pack coverage. |
 | `forgeguard doctor` | Verify configuration, Git, and required local tools. |
 | `forgeguard mode` | Check or change project/global operating mode. |
+| `forgeguard config migrate` | Upgrade config v1 to v2 without resetting commands or focus settings. |
 | `forgeguard gate` | Run static rules and configured quality commands. |
 | `forgeguard review` | Scan Git-changed files without running commands. |
 | `forgeguard baseline create` | Record current static findings so gates report only new findings. |
@@ -394,8 +408,8 @@ Agents must follow `inspect → design → implement → test → review → ver
 
 ForgeGuard separates rules into:
 
-1. **Deterministic:** failed tests, database I/O inside a proven loop, or failed build commands can block.
-2. **Heuristic:** possible nested scans or duplicate code provide evidence and require review.
+1. **Deterministic/semantic:** failed commands and provenance-confirmed database/network calls can block.
+2. **Structural/heuristic:** possible nested scans, receiver-name matches, and duplicate code provide review evidence with explicit confidence.
 3. **Evidence-based:** performance and quality improvements require benchmarks, query plans, profiler output, or evaluation reports.
 
 See [Rule catalog](docs/RULES.md) and [Architecture](docs/ARCHITECTURE.md).
@@ -407,13 +421,15 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace
 cargo build --workspace
+cargo deny check
+cargo audit --deny warnings
 ```
 
 Maintainers publish binaries by pushing a tag matching the workspace version, for example `v0.2.0`. The release workflow verifies the tag, tests the repository and installers, builds six native platform archives, generates checksums, and publishes the GitHub Release automatically.
 
 ## Security
 
-ForgeGuard executes commands declared in a repository's `.forgeguard/config.toml`. Review configuration and agent hooks before trusting an untrusted repository. See [SECURITY.md](SECURITY.md).
+ForgeGuard executes commands declared in a repository's `.forgeguard/config.toml`. Review configuration and agent hooks before trusting an untrusted repository. CI runs `cargo-deny` and `cargo-audit`; GitHub Actions are commit-SHA pinned and updated through Dependabot. See [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/crates/forgeguard-cli/Cargo.toml
+++ b/crates/forgeguard-cli/Cargo.toml
@@ -20,4 +20,4 @@ anyhow.workspace = true
 clap.workspace = true
 inquire.workspace = true
 serde_json.workspace = true
-forgeguard-core = { path = "../forgeguard-core" }
+forgeguard-core = { version = "0.8.0", path = "../forgeguard-core" }

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -9,15 +9,15 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use forgeguard_core::{
     config::{ForgeGuardConfig, CONFIG_FILE},
-    create_baseline, detect_project, evaluate_context_hook, evaluate_scope_hook,
+    create_baseline_with_config, detect_project, evaluate_context_hook, evaluate_scope_hook,
     evaluate_stop_hook,
     git::changed_files,
     initialize_global, initialize_project, mark_task_ready_with_confidence, render_context_hook,
     render_hook_decision, render_scope_warning,
-    report::{render_detection, render_doctor, render_gate, render_gate_compact},
+    report::{render_detection, render_doctor, render_gate, render_gate_compact, render_sarif},
     run_doctor, run_gate, start_task_with_contract, task_state, update_task_todos, AgentTarget,
     GateOptions, GateReport, GateStatus, GoalContract, GuardMode, HookAgent, HookDecision,
-    InitOptions, BASELINE_FILE,
+    InitOptions, BASELINE_FILE, LANGUAGE_CAPABILITIES, RULES,
 };
 
 #[derive(Debug, Parser)]
@@ -58,6 +58,11 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Show parser, structural-rule, and semantic-pack coverage.
+    Capabilities {
+        #[arg(long)]
+        json: bool,
+    },
     /// Check or change ForgeGuard mode.
     Mode {
         #[arg(value_enum)]
@@ -66,6 +71,11 @@ enum Commands {
         global: bool,
         #[arg(long)]
         json: bool,
+    },
+    /// Inspect or migrate ForgeGuard configuration.
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommands,
     },
     /// Check configuration and required local tools.
     Doctor {
@@ -129,6 +139,7 @@ enum OutputArg {
     Full,
     Compact,
     Quiet,
+    Sarif,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -136,6 +147,15 @@ enum ModeArg {
     Default,
     Lite,
     Strict,
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigCommands {
+    /// Upgrade a version 1 configuration to version 2 without resetting commands.
+    Migrate {
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -328,7 +348,50 @@ fn execute() -> Result<ExitCode> {
             }
             Ok(ExitCode::SUCCESS)
         }
+        Commands::Capabilities { json } => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "workflow_support": "all initialized repositories",
+                        "languages": LANGUAGE_CAPABILITIES,
+                        "rules": RULES,
+                    }))?
+                );
+            } else {
+                println!("ForgeGuard capabilities");
+                println!("Workflow support: all initialized repositories");
+                for capability in LANGUAGE_CAPABILITIES {
+                    println!(
+                        "  {}: parser={}, structural={}, semantic={}",
+                        capability.language,
+                        capability.parser,
+                        capability.structural_rules,
+                        capability.semantic_pack
+                    );
+                }
+            }
+            Ok(ExitCode::SUCCESS)
+        }
         Commands::Mode { mode, global, json } => execute_mode(&root, mode, global, json),
+        Commands::Config {
+            command: ConfigCommands::Migrate { json },
+        } => {
+            let mut config = ForgeGuardConfig::load(&root)?;
+            let previous = config.migrate_to_v2()?;
+            config.save(&root)?;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({"previous_version": previous, "version": config.version})
+                );
+            } else if previous == config.version {
+                println!("ForgeGuard config already at version {}.", config.version);
+            } else {
+                println!("ForgeGuard config migrated from version {previous} to 2.");
+            }
+            Ok(ExitCode::SUCCESS)
+        }
         Commands::Doctor { json } => {
             let config = if root.join(CONFIG_FILE).exists() {
                 Some(ForgeGuardConfig::load(&root)?)
@@ -395,7 +458,7 @@ fn execute() -> Result<ExitCode> {
             let config = ForgeGuardConfig::load(&root).context(
                 "ForgeGuard is not initialized; run `forgeguard init` in the repository first",
             )?;
-            let baseline = create_baseline(&root, &config.scan, force)?;
+            let baseline = create_baseline_with_config(&root, &config, force)?;
             if json {
                 println!(
                     "{}",
@@ -688,6 +751,7 @@ fn render_gate_output(report: &GateReport, json: bool, output: OutputArg) -> Res
             OutputArg::Full => print!("{}", render_gate(report)),
             OutputArg::Compact => println!("{}", render_gate_compact(report)),
             OutputArg::Quiet => {}
+            OutputArg::Sarif => println!("{}", render_sarif(report)?),
         }
     }
     Ok(())
@@ -811,7 +875,9 @@ fn render_file_changes(written: &[String], skipped: &[String]) {
 mod tests {
     use clap::Parser;
 
-    use super::{agents_from_names, AgentTarget, BaselineCommands, Cli, Commands};
+    use super::{
+        agents_from_names, AgentTarget, BaselineCommands, Cli, Commands, ConfigCommands, OutputArg,
+    };
 
     #[test]
     fn maps_checked_names_in_menu_order() {
@@ -846,6 +912,28 @@ mod tests {
                     force: true,
                     json: true
                 }
+            }
+        ));
+    }
+
+    #[test]
+    fn parses_config_migration_and_sarif_output() {
+        let migrate = Cli::try_parse_from(["forgeguard", "config", "migrate", "--json"])
+            .expect("parse config migration");
+        assert!(matches!(
+            migrate.command,
+            Commands::Config {
+                command: ConfigCommands::Migrate { json: true }
+            }
+        ));
+
+        let sarif = Cli::try_parse_from(["forgeguard", "gate", "--output", "sarif"])
+            .expect("parse SARIF output");
+        assert!(matches!(
+            sarif.command,
+            Commands::Gate {
+                output: OutputArg::Sarif,
+                ..
             }
         ));
     }

--- a/crates/forgeguard-core/src/baseline.rs
+++ b/crates/forgeguard-core/src/baseline.rs
@@ -8,13 +8,13 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    config::ScanConfig,
+    config::{ForgeGuardConfig, ScanConfig},
     model::{Finding, Severity},
     scanner::{scan_project, ScanOptions},
 };
 
 pub const BASELINE_FILE: &str = ".forgeguard/baseline.json";
-const BASELINE_VERSION: u32 = 1;
+const BASELINE_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Baseline {
@@ -34,7 +34,6 @@ pub struct BaselineEntry {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct BaselineKey {
     rule_id: String,
-    severity: Severity,
     path: String,
     evidence: String,
 }
@@ -43,15 +42,18 @@ impl Baseline {
     pub fn from_findings(findings: &[Finding]) -> Self {
         let mut counts = BTreeMap::new();
         for finding in findings {
-            *counts.entry(key_for_finding(finding)).or_insert(0) += 1;
+            let (_, count) = counts
+                .entry(key_for_finding(finding))
+                .or_insert((finding.severity, 0usize));
+            *count = count.saturating_add(1);
         }
         Self {
             version: BASELINE_VERSION,
             findings: counts
                 .into_iter()
-                .map(|(key, count)| BaselineEntry {
+                .map(|(key, (severity, count))| BaselineEntry {
                     rule_id: key.rule_id,
-                    severity: key.severity,
+                    severity,
                     path: key.path,
                     evidence: key.evidence,
                     count,
@@ -69,7 +71,7 @@ impl Baseline {
             .with_context(|| format!("failed to read {}", path.display()))?;
         let baseline: Self = serde_json::from_str(&source)
             .with_context(|| format!("failed to parse {}", path.display()))?;
-        if baseline.version != BASELINE_VERSION {
+        if !matches!(baseline.version, 1 | BASELINE_VERSION) {
             bail!(
                 "unsupported baseline version {} in {}; expected {}",
                 baseline.version,
@@ -113,6 +115,23 @@ impl Baseline {
 }
 
 pub fn create_baseline(root: &Path, config: &ScanConfig, force: bool) -> Result<Baseline> {
+    ensure_baseline_can_be_created(root, force)?;
+    let findings = scan_project(root, config, &ScanOptions::default())?;
+    write_baseline(root, &findings)
+}
+
+pub fn create_baseline_with_config(
+    root: &Path,
+    config: &ForgeGuardConfig,
+    force: bool,
+) -> Result<Baseline> {
+    ensure_baseline_can_be_created(root, force)?;
+    let mut findings = scan_project(root, &config.scan, &ScanOptions::default())?;
+    findings.retain_mut(|finding| config.apply_rule(&finding.rule_id, &mut finding.severity));
+    write_baseline(root, &findings)
+}
+
+fn ensure_baseline_can_be_created(root: &Path, force: bool) -> Result<()> {
     let path = root.join(BASELINE_FILE);
     if path.exists() && !force {
         bail!(
@@ -120,9 +139,12 @@ pub fn create_baseline(root: &Path, config: &ScanConfig, force: bool) -> Result<
             path.display()
         );
     }
+    Ok(())
+}
 
-    let findings = scan_project(root, config, &ScanOptions::default())?;
-    let baseline = Baseline::from_findings(&findings);
+fn write_baseline(root: &Path, findings: &[Finding]) -> Result<Baseline> {
+    let path = root.join(BASELINE_FILE);
+    let baseline = Baseline::from_findings(findings);
     let parent = path
         .parent()
         .context("ForgeGuard baseline path has no parent")?;
@@ -137,7 +159,6 @@ pub fn create_baseline(root: &Path, config: &ScanConfig, force: bool) -> Result<
 fn key_for_finding(finding: &Finding) -> BaselineKey {
     BaselineKey {
         rule_id: finding.rule_id.clone(),
-        severity: finding.severity,
         path: portable_path(&finding.path),
         evidence: finding.evidence.clone(),
     }
@@ -146,7 +167,6 @@ fn key_for_finding(finding: &Finding) -> BaselineKey {
 fn key_for_entry(entry: &BaselineEntry) -> BaselineKey {
     BaselineKey {
         rule_id: entry.rule_id.clone(),
-        severity: entry.severity,
         path: entry.path.clone(),
         evidence: entry.evidence.clone(),
     }

--- a/crates/forgeguard-core/src/config.rs
+++ b/crates/forgeguard-core/src/config.rs
@@ -1,7 +1,9 @@
-use std::{fs, path::Path};
+use std::{collections::BTreeMap, fs, path::Path};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
+
+use crate::model::Severity;
 
 pub const CONFIG_DIR: &str = ".forgeguard";
 pub const CONFIG_FILE: &str = ".forgeguard/config.toml";
@@ -13,9 +15,9 @@ pub enum GuardMode {
     /// Token-friendly default: report static findings but block only failed required commands.
     #[default]
     Default,
-    /// Report-only mode: never blocks; useful for baselining and cleanup lists.
+    /// Static report-only mode; required command failures still block.
     Lite,
-    /// Full guard mode: blocks failed required commands and error-level deterministic findings.
+    /// Full guard mode: blocks failed required commands and version-aware static findings.
     #[serde(alias = "guard")]
     Strict,
 }
@@ -91,6 +93,24 @@ pub struct FocusConfig {
     pub min_hill_climbability: u8,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PolicyConfig {
+    /// Overrides the mode default. Lite mode always remains report-only for
+    /// static findings.
+    #[serde(default)]
+    pub warnings_block: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RuleConfig {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub severity: Option<Severity>,
+    #[serde(default)]
+    pub block: Option<bool>,
+}
+
 impl Default for FocusConfig {
     fn default() -> Self {
         Self {
@@ -118,6 +138,10 @@ pub struct ForgeGuardConfig {
     pub commands: Vec<CommandConfig>,
     #[serde(default)]
     pub focus: FocusConfig,
+    #[serde(default)]
+    pub policies: PolicyConfig,
+    #[serde(default)]
+    pub rules: BTreeMap<String, RuleConfig>,
 }
 
 impl ForgeGuardConfig {
@@ -131,7 +155,49 @@ impl ForgeGuardConfig {
             scan: ScanConfig::default(),
             commands,
             focus: FocusConfig::default(),
+            policies: PolicyConfig::default(),
+            rules: BTreeMap::new(),
         }
+    }
+
+    pub fn apply_rule(&self, rule_id: &str, severity: &mut Severity) -> bool {
+        let Some(rule) = self.rules.get(rule_id) else {
+            return true;
+        };
+        if rule.enabled == Some(false) {
+            return false;
+        }
+        if let Some(override_severity) = rule.severity {
+            *severity = override_severity;
+        }
+        true
+    }
+
+    pub fn blocks_finding(&self, rule_id: &str, severity: Severity) -> bool {
+        if self.mode == GuardMode::Lite {
+            return false;
+        }
+        if let Some(block) = self.rules.get(rule_id).and_then(|rule| rule.block) {
+            return block;
+        }
+        match self.policies.warnings_block {
+            Some(true) => severity >= Severity::Warning,
+            Some(false) => self.mode == GuardMode::Strict && severity == Severity::Error,
+            None if self.version >= 2 && self.mode == GuardMode::Strict => {
+                severity >= Severity::Warning
+            }
+            None if self.mode == GuardMode::Strict => severity == Severity::Error,
+            None => false,
+        }
+    }
+
+    pub fn migrate_to_v2(&mut self) -> Result<u32> {
+        if !matches!(self.version, 1 | 2) {
+            bail!("cannot migrate unsupported config version {}", self.version);
+        }
+        let previous = self.version;
+        self.version = 2;
+        Ok(previous)
     }
 
     pub fn load(root: &Path) -> Result<Self> {
@@ -153,7 +219,16 @@ impl ForgeGuardConfig {
     fn load_from_path(path: &Path) -> Result<Self> {
         let source = fs::read_to_string(path)
             .with_context(|| format!("failed to read {}", path.display()))?;
-        toml::from_str(&source).with_context(|| format!("failed to parse {}", path.display()))
+        let config: Self = toml::from_str(&source)
+            .with_context(|| format!("failed to parse {}", path.display()))?;
+        if !matches!(config.version, 1 | 2) {
+            bail!(
+                "unsupported config version {} in {}; expected 1 or 2",
+                config.version,
+                path.display()
+            );
+        }
+        Ok(config)
     }
 
     fn save_to_path(&self, path: &Path) -> Result<()> {
@@ -172,7 +247,7 @@ fn default_true() -> bool {
 }
 
 fn default_config_version() -> u32 {
-    1
+    2
 }
 
 fn default_max_file_bytes() -> u64 {

--- a/crates/forgeguard-core/src/duplication.rs
+++ b/crates/forgeguard-core/src/duplication.rs
@@ -5,7 +5,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::model::{Finding, Severity};
+use crate::{
+    model::{EvidenceConfidence, Finding, Severity},
+    rules,
+    scanner::canonical_functions,
+};
 
 #[derive(Debug, Clone)]
 struct Occurrence {
@@ -84,6 +88,10 @@ pub fn scan_duplicate_blocks(
                 rule_id: "FG-DRY-001".to_owned(),
                 title: "Potential duplicated implementation".to_owned(),
                 severity: Severity::Info,
+                confidence: rules::metadata("FG-DRY-001")
+                    .map(|rule| rule.confidence)
+                    .unwrap_or(EvidenceConfidence::Heuristic),
+                blocking: false,
                 path: target.path.clone(),
                 line: target.line,
                 evidence: format!(
@@ -93,6 +101,98 @@ pub fn scan_duplicate_blocks(
                     other.line
                 ),
                 recommendation: "Verify that both blocks represent the same responsibility and lifecycle. Extract the narrowest valid shared abstraction only when they should evolve together.".to_owned(),
+            });
+        }
+    }
+    findings.extend(scan_renamed_duplicate_blocks(
+        root,
+        files,
+        block_lines,
+        focus_paths,
+    ));
+    findings
+}
+
+#[derive(Debug, Clone)]
+struct CloneOccurrence {
+    path: PathBuf,
+    line: usize,
+    canonical: String,
+    original: String,
+}
+
+fn scan_renamed_duplicate_blocks(
+    root: &Path,
+    files: &[PathBuf],
+    minimum_lines: usize,
+    focus_paths: Option<&BTreeSet<PathBuf>>,
+) -> Vec<Finding> {
+    let mut groups = BTreeMap::<u64, Vec<CloneOccurrence>>::new();
+    for path in files {
+        let Ok(source) = fs::read_to_string(path) else {
+            continue;
+        };
+        // forgeguard: allow FG-ALG-001 -- functions are disjoint per file; total traversal is O(AST nodes)
+        for function in canonical_functions(path, &source, minimum_lines) {
+            let mut hasher = DefaultHasher::new();
+            function.profile.hash(&mut hasher);
+            function.canonical.hash(&mut hasher);
+            groups
+                .entry(hasher.finish())
+                .or_default()
+                .push(CloneOccurrence {
+                    path: path.strip_prefix(root).unwrap_or(path).to_path_buf(),
+                    line: function.line,
+                    canonical: function.canonical,
+                    original: function.original,
+                });
+        }
+    }
+
+    let mut findings = Vec::new();
+    let mut reported_pairs = BTreeSet::new();
+    for occurrences in groups.into_values() {
+        let Some(first) = occurrences.first() else {
+            continue;
+        };
+        // forgeguard: allow FG-ALG-001 -- hash groups are disjoint; total traversal is O(occurrences)
+        for duplicate in occurrences.iter().skip(1) {
+            if first.path == duplicate.path
+                || first.canonical != duplicate.canonical
+                || first.original == duplicate.original
+            {
+                continue;
+            }
+            let (target, other) = match focus_paths {
+                Some(focus) if focus.contains(&duplicate.path) => (duplicate, first),
+                Some(focus) if focus.contains(&first.path) => (first, duplicate),
+                Some(_) => continue,
+                None => (duplicate, first),
+            };
+            let pair = if first.path <= duplicate.path {
+                (first.path.clone(), duplicate.path.clone())
+            } else {
+                (duplicate.path.clone(), first.path.clone())
+            };
+            if !reported_pairs.insert(pair) {
+                continue;
+            }
+            findings.push(Finding {
+                rule_id: "FG-DRY-002".to_owned(),
+                title: "Potential renamed duplicated implementation".to_owned(),
+                severity: Severity::Info,
+                confidence: rules::metadata("FG-DRY-002")
+                    .map(|rule| rule.confidence)
+                    .unwrap_or(EvidenceConfidence::Heuristic),
+                blocking: false,
+                path: target.path.clone(),
+                line: target.line,
+                evidence: format!(
+                    "An alpha-renamed function also appears at {}:{}",
+                    other.path.display(),
+                    other.line
+                ),
+                recommendation: "Confirm both functions share responsibility before extracting a common implementation.".to_owned(),
             });
         }
     }

--- a/crates/forgeguard-core/src/gate.rs
+++ b/crates/forgeguard-core/src/gate.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use crate::{
     baseline::Baseline,
-    config::{ForgeGuardConfig, GuardMode},
+    config::ForgeGuardConfig,
     model::{GateReport, GateStatus, GateSummary, Severity},
     runner::run_checks,
     scanner::{scan_project, ScanOptions},
@@ -31,6 +31,7 @@ pub fn run_gate(
     findings.dedup_by(|left, right| {
         left.rule_id == right.rule_id && left.path == right.path && left.line == right.line
     });
+    findings.retain_mut(|finding| config.apply_rule(&finding.rule_id, &mut finding.severity));
     let findings_baselined = match Baseline::load(root)? {
         Some(baseline) => baseline.filter(&mut findings),
         None => 0,
@@ -53,11 +54,15 @@ pub fn run_gate(
         .iter()
         .filter(|finding| finding.severity == Severity::Info)
         .count();
+    for finding in &mut findings {
+        finding.blocking = config.blocks_finding(&finding.rule_id, finding.severity);
+    }
+    let blocking_findings = findings.iter().filter(|finding| finding.blocking).count();
     let checks_passed = checks.iter().filter(|check| check.success).count();
     let checks_failed = checks.iter().filter(|check| !check.success).count();
     let required_check_failed = checks.iter().any(|check| check.required && !check.success);
 
-    let status = if required_check_failed || config.mode == GuardMode::Strict && errors > 0 {
+    let status = if required_check_failed || blocking_findings > 0 {
         GateStatus::Blocked
     } else if errors + warnings + info + checks_failed > 0 {
         GateStatus::Warning
@@ -73,6 +78,7 @@ pub fn run_gate(
             errors,
             warnings,
             info,
+            blocking_findings,
             findings_baselined,
             checks_passed,
             checks_failed,

--- a/crates/forgeguard-core/src/lib.rs
+++ b/crates/forgeguard-core/src/lib.rs
@@ -9,11 +9,14 @@ pub mod hook;
 pub mod init;
 pub mod model;
 pub mod report;
+pub mod rules;
 pub mod runner;
 pub mod scanner;
 pub mod update;
 
-pub use baseline::{create_baseline, Baseline, BaselineEntry, BASELINE_FILE};
+pub use baseline::{
+    create_baseline, create_baseline_with_config, Baseline, BaselineEntry, BASELINE_FILE,
+};
 pub use config::{CommandConfig, FocusConfig, ForgeGuardConfig, GuardMode};
 pub use detector::{detect_project, ProjectDetection};
 pub use doctor::{run_doctor, DoctorReport};
@@ -27,5 +30,6 @@ pub use hook::{
 pub use init::{
     initialize_global, initialize_project, AgentTarget, GlobalInitReport, InitOptions, InitReport,
 };
-pub use model::{CheckResult, Finding, GateReport, GateStatus, Severity};
+pub use model::{CheckResult, EvidenceConfidence, Finding, GateReport, GateStatus, Severity};
+pub use rules::{LanguageCapability, RuleMetadata, LANGUAGE_CAPABILITIES, RULES};
 pub use scanner::{scan_project, ScanOptions};

--- a/crates/forgeguard-core/src/model.rs
+++ b/crates/forgeguard-core/src/model.rs
@@ -10,6 +10,27 @@ pub enum Severity {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum EvidenceConfidence {
+    Deterministic,
+    Semantic,
+    Structural,
+    #[default]
+    Heuristic,
+}
+
+impl EvidenceConfidence {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Deterministic => "deterministic",
+            Self::Semantic => "semantic",
+            Self::Structural => "structural",
+            Self::Heuristic => "heuristic",
+        }
+    }
+}
+
 impl Severity {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -25,6 +46,10 @@ pub struct Finding {
     pub rule_id: String,
     pub title: String,
     pub severity: Severity,
+    #[serde(default)]
+    pub confidence: EvidenceConfidence,
+    #[serde(default)]
+    pub blocking: bool,
     pub path: PathBuf,
     pub line: usize,
     pub evidence: String,
@@ -65,6 +90,7 @@ pub struct GateSummary {
     pub errors: usize,
     pub warnings: usize,
     pub info: usize,
+    pub blocking_findings: usize,
     pub findings_baselined: usize,
     pub checks_passed: usize,
     pub checks_failed: usize,

--- a/crates/forgeguard-core/src/report.rs
+++ b/crates/forgeguard-core/src/report.rs
@@ -1,6 +1,8 @@
 use std::fmt::Write;
 
-use crate::{doctor::DoctorReport, model::GateReport, ProjectDetection};
+use serde_json::json;
+
+use crate::{doctor::DoctorReport, model::GateReport, rules::RULES, ProjectDetection, Severity};
 
 pub const COMPACT_MAX_CHARS: usize = 2_000;
 const COMPACT_MAX_FINDINGS: usize = 5;
@@ -117,6 +119,63 @@ pub fn render_gate_compact(report: &GateReport) -> String {
         let _ = writeln!(output, "- check {} failed: {evidence}", check.name);
     }
     truncate_chars(output.trim(), COMPACT_MAX_CHARS)
+}
+
+pub fn render_sarif(report: &GateReport) -> Result<String, serde_json::Error> {
+    let rules = RULES
+        .iter()
+        .map(|rule| {
+            json!({
+                "id": rule.id,
+                "name": rule.title,
+                "shortDescription": {"text": rule.title},
+                "defaultConfiguration": {"level": sarif_level(rule.default_severity)},
+                "properties": {"confidence": rule.confidence.as_str()},
+            })
+        })
+        .collect::<Vec<_>>();
+    let results = report
+        .findings
+        .iter()
+        .map(|finding| {
+            json!({
+                "ruleId": finding.rule_id,
+                "level": sarif_level(finding.severity),
+                "message": {
+                    "text": format!("{} Evidence: {} Fix: {}", finding.title, finding.evidence, finding.recommendation),
+                },
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": finding.path.to_string_lossy()},
+                        "region": {"startLine": finding.line},
+                    }
+                }],
+                "partialFingerprints": {
+                    "forgeguardFinding": format!("{}:{}:{}", finding.rule_id, finding.path.display(), finding.evidence),
+                },
+                "properties": {
+                    "confidence": finding.confidence.as_str(),
+                    "blocking": finding.blocking,
+                },
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_string_pretty(&json!({
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {"driver": {"name": "ForgeGuard", "rules": rules}},
+            "results": results,
+        }],
+    }))
+}
+
+fn sarif_level(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+        Severity::Info => "note",
+    }
 }
 
 pub fn render_doctor(report: &DoctorReport) -> String {

--- a/crates/forgeguard-core/src/rules.rs
+++ b/crates/forgeguard-core/src/rules.rs
@@ -1,0 +1,162 @@
+use serde::Serialize;
+
+use crate::model::{EvidenceConfidence, Severity};
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct RuleMetadata {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub default_severity: Severity,
+    pub confidence: EvidenceConfidence,
+}
+
+pub const RULES: &[RuleMetadata] = &[
+    rule(
+        "FG-ALG-001",
+        "Potential nested iteration",
+        Severity::Warning,
+        EvidenceConfidence::Structural,
+    ),
+    rule(
+        "FG-ALG-002",
+        "Repeated linear lookup inside iteration",
+        Severity::Warning,
+        EvidenceConfidence::Heuristic,
+    ),
+    rule(
+        "FG-ALG-003",
+        "Sorting inside iteration",
+        Severity::Warning,
+        EvidenceConfidence::Structural,
+    ),
+    rule(
+        "FG-DB-001",
+        "Database operation inside iteration",
+        Severity::Error,
+        EvidenceConfidence::Semantic,
+    ),
+    rule(
+        "FG-DB-002",
+        "Potential database operation inside iteration",
+        Severity::Info,
+        EvidenceConfidence::Heuristic,
+    ),
+    rule(
+        "FG-DB-005",
+        "Potential unnecessary SELECT *",
+        Severity::Warning,
+        EvidenceConfidence::Heuristic,
+    ),
+    rule(
+        "FG-NET-001",
+        "External request inside iteration",
+        Severity::Warning,
+        EvidenceConfidence::Semantic,
+    ),
+    rule(
+        "FG-NET-002",
+        "Potential external request inside iteration",
+        Severity::Info,
+        EvidenceConfidence::Heuristic,
+    ),
+    rule(
+        "FG-CON-001",
+        "Potential unbounded parallel execution",
+        Severity::Warning,
+        EvidenceConfidence::Structural,
+    ),
+    rule(
+        "FG-DRY-001",
+        "Potential duplicated implementation",
+        Severity::Info,
+        EvidenceConfidence::Structural,
+    ),
+    rule(
+        "FG-DRY-002",
+        "Potential renamed duplicated implementation",
+        Severity::Info,
+        EvidenceConfidence::Heuristic,
+    ),
+    rule(
+        "FG-ARCH-001",
+        "Large inline data literal",
+        Severity::Warning,
+        EvidenceConfidence::Structural,
+    ),
+    rule(
+        "FG-PARSE-001",
+        "Structural analysis skipped",
+        Severity::Info,
+        EvidenceConfidence::Deterministic,
+    ),
+];
+
+const fn rule(
+    id: &'static str,
+    title: &'static str,
+    default_severity: Severity,
+    confidence: EvidenceConfidence,
+) -> RuleMetadata {
+    RuleMetadata {
+        id,
+        title,
+        default_severity,
+        confidence,
+    }
+}
+
+pub fn metadata(rule_id: &str) -> Option<&'static RuleMetadata> {
+    RULES.iter().find(|rule| rule.id == rule_id)
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct LanguageCapability {
+    pub language: &'static str,
+    pub parser: bool,
+    pub structural_rules: bool,
+    pub semantic_pack: bool,
+}
+
+pub const LANGUAGE_CAPABILITIES: &[LanguageCapability] = &[
+    capability("JavaScript/TypeScript", true),
+    capability("Python", true),
+    capability("Rust", true),
+    capability("Go", true),
+    structural("Java/Kotlin"),
+    structural("C#"),
+    structural("C/C++"),
+    structural("Ruby"),
+    structural("PHP"),
+    structural("Swift"),
+    structural("Dart"),
+    structural("Shell"),
+    structural("Zig"),
+    structural("Lua"),
+    structural("Scala"),
+    structural("Solidity"),
+    structural("R"),
+    parser_only("Elixir/Erlang"),
+    parser_only("HCL/Terraform"),
+];
+
+const fn capability(language: &'static str, semantic_pack: bool) -> LanguageCapability {
+    LanguageCapability {
+        language,
+        parser: true,
+        structural_rules: true,
+        semantic_pack,
+    }
+}
+
+const fn structural(language: &'static str) -> LanguageCapability {
+    capability(language, false)
+}
+
+const fn parser_only(language: &'static str) -> LanguageCapability {
+    LanguageCapability {
+        language,
+        parser: true,
+        structural_rules: false,
+        semantic_pack: false,
+    }
+}

--- a/crates/forgeguard-core/src/scanner.rs
+++ b/crates/forgeguard-core/src/scanner.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fs,
     path::Path,
 };
@@ -12,7 +12,8 @@ use tree_sitter::{Language, Node, Parser};
 use crate::{
     config::ScanConfig,
     duplication::scan_duplicate_blocks,
-    model::{Finding, Severity},
+    model::{EvidenceConfidence, Finding, Severity},
+    rules,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -33,6 +34,12 @@ pub fn scan_project(
     let mut analyzer = Analyzer::new()?;
     let mut findings = Vec::new();
     let files = collect_source_files(root, config, options)?;
+    let project_files = if options.paths.is_some() {
+        collect_source_files(root, config, &ScanOptions::default())?
+    } else {
+        files.clone()
+    };
+    let semantic = SemanticIndex::build(&project_files);
 
     for path in &files {
         let metadata =
@@ -44,7 +51,7 @@ pub fn scan_project(
             continue;
         };
         let mut file_findings = Vec::new();
-        analyzer.scan_file(root, path, &source, &mut file_findings);
+        analyzer.scan_file(root, path, &source, &semantic, &mut file_findings);
         apply_inline_suppressions(&source, &mut file_findings);
         findings.extend(file_findings);
     }
@@ -55,14 +62,9 @@ pub fn scan_project(
             .map(|path| path.strip_prefix(root).unwrap_or(path).to_path_buf())
             .collect::<BTreeSet<_>>()
     });
-    let duplication_files = if options.paths.is_some() {
-        collect_source_files(root, config, &ScanOptions::default())?
-    } else {
-        files.clone()
-    };
     findings.extend(scan_duplicate_blocks(
         root,
-        &duplication_files,
+        &project_files,
         config.duplicate_block_lines,
         focus_paths.as_ref(),
     ));
@@ -251,6 +253,426 @@ struct Analyzer {
     ts_lang: Regex,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct SinkSet(u8);
+
+impl SinkSet {
+    const DATABASE: Self = Self(1);
+    const NETWORK: Self = Self(2);
+
+    fn contains(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    fn insert(&mut self, other: Self) -> bool {
+        let previous = self.0;
+        self.0 |= other.0;
+        self.0 != previous
+    }
+}
+
+#[derive(Default)]
+struct FileProvenance {
+    database_symbols: HashSet<String>,
+    network_symbols: HashSet<String>,
+    local_symbols: HashSet<String>,
+}
+
+impl FileProvenance {
+    fn from_source(profile: LanguageProfile, source: &str) -> Self {
+        let mut provenance = Self::default();
+        for line in source.lines() {
+            let lower = line.to_ascii_lowercase();
+            let trimmed = line.trim_start();
+            let import_like = trimmed.starts_with("import ")
+                || trimmed.starts_with("from ")
+                || trimmed.starts_with("use ")
+                || trimmed.contains("require(");
+            if import_like {
+                let declaration = line.split(['\"', '\'']).next().unwrap_or(line);
+                provenance.local_symbols.extend(
+                    identifiers(declaration)
+                        .into_iter()
+                        .filter(|word| !binding_keywords().contains(&word.as_str())),
+                );
+                if let Some(path) = quoted_value(line) {
+                    if let Some(name) = path.rsplit('/').next() {
+                        provenance
+                            .local_symbols
+                            .insert(name.replace(['-', '.'], "_"));
+                    }
+                }
+            }
+            // forgeguard: allow FG-ALG-001 -- semantic package catalogs are fixed at eight entries or fewer
+            for (package, kind) in semantic_packages(profile) {
+                if !import_like || !contains_package(&lower, package) {
+                    continue;
+                }
+                let declaration = line.split(['\"', '\'']).next().unwrap_or(line);
+                let symbols = identifiers(declaration)
+                    .into_iter()
+                    .filter(|word| !binding_keywords().contains(&word.as_str()));
+                let target = if *kind == SinkSet::DATABASE {
+                    &mut provenance.database_symbols
+                } else {
+                    &mut provenance.network_symbols
+                };
+                target.extend(symbols);
+                if let Some(default) = package
+                    .rsplit('/')
+                    .next()
+                    .and_then(|part| part.rsplit('.').next())
+                {
+                    target.insert(default.replace('-', "_"));
+                }
+            }
+        }
+        if matches!(
+            profile,
+            LanguageProfile::JavaScript | LanguageProfile::TypeScript | LanguageProfile::Tsx
+        ) {
+            provenance.network_symbols.insert("fetch".to_owned());
+        }
+
+        // Resolve direct assignments such as `const prisma = new PrismaClient()`
+        // and `db, err := sql.Open(...)`. This stays lexical and path-insensitive.
+        for _ in 0..4 {
+            let mut changed = false;
+            // forgeguard: allow FG-ALG-001 -- assignment propagation is capped at four passes
+            for line in source.lines() {
+                let Some((left, right)) = line.split_once('=') else {
+                    continue;
+                };
+                // forgeguard: allow FG-ALG-002 -- keyword catalog is a fixed nine-entry slice
+                let Some(binding) = identifiers(left)
+                    .into_iter()
+                    .find(|word| !binding_keywords().contains(&word.as_str()))
+                else {
+                    continue;
+                };
+                let right_symbols = identifiers(&without_strings(right));
+                if right_symbols
+                    .iter()
+                    .any(|word| provenance.database_symbols.contains(word))
+                {
+                    changed |= provenance.database_symbols.insert(binding.clone());
+                }
+                if right_symbols
+                    .iter()
+                    .any(|word| provenance.network_symbols.contains(word))
+                {
+                    changed |= provenance.network_symbols.insert(binding);
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        provenance
+    }
+
+    fn classify(&self, callee: &str, method: &str) -> SinkSet {
+        let parts = identifiers(callee);
+        let mut sinks = SinkSet::default();
+        if parts
+            .iter()
+            .any(|part| self.database_symbols.contains(part))
+            && database_methods().contains(&normalized_method(method).as_str())
+        {
+            sinks.insert(SinkSet::DATABASE);
+        }
+        if parts.iter().any(|part| self.network_symbols.contains(part))
+            && network_methods().contains(&normalized_method(method).as_str())
+        {
+            sinks.insert(SinkSet::NETWORK);
+        }
+        sinks
+    }
+}
+
+#[derive(Default)]
+struct SemanticIndex {
+    files: HashMap<std::path::PathBuf, FileProvenance>,
+    functions: HashMap<String, SinkSet>,
+}
+
+struct FunctionDraft {
+    name: String,
+    sinks: SinkSet,
+    calls: Vec<String>,
+}
+
+fn collect_function_drafts(
+    root: Node<'_>,
+    source: &str,
+    profile: LanguageProfile,
+    provenance: &FileProvenance,
+    drafts: &mut Vec<FunctionDraft>,
+    counts: &mut HashMap<String, usize>,
+) {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if profile.is_function(node.kind()) {
+            let Some(name) = node
+                .child_by_field_name("name")
+                .map(|name| node_text(name, source).to_owned())
+            else {
+                continue;
+            };
+            let body = node.child_by_field_name("body").unwrap_or(node);
+            let mut sinks = SinkSet::default();
+            let mut calls = Vec::new();
+            let mut body_stack = vec![body];
+            // forgeguard: allow FG-ALG-001 -- function bodies are disjoint; nested functions are skipped here
+            while let Some(child) = body_stack.pop() {
+                if child != body && profile.is_function(child.kind()) {
+                    continue;
+                }
+                if let Some(callee) = call_name(child, source) {
+                    let method = terminal_name(callee);
+                    sinks.insert(provenance.classify(callee, method));
+                    calls.push(method.to_owned());
+                }
+                body_stack.extend(
+                    (0..child.named_child_count())
+                        .filter_map(|index| child.named_child(index as u32)),
+                );
+            }
+            *counts.entry(name.clone()).or_default() += 1;
+            drafts.push(FunctionDraft { name, sinks, calls });
+        }
+        stack.extend(
+            (0..node.named_child_count()).filter_map(|index| node.named_child(index as u32)),
+        );
+    }
+}
+
+fn semantic_packages(profile: LanguageProfile) -> &'static [(&'static str, SinkSet)] {
+    const JS: &[(&str, SinkSet)] = &[
+        ("@prisma/client", SinkSet::DATABASE),
+        ("sequelize", SinkSet::DATABASE),
+        ("typeorm", SinkSet::DATABASE),
+        ("drizzle-orm", SinkSet::DATABASE),
+        ("mongoose", SinkSet::DATABASE),
+        ("axios", SinkSet::NETWORK),
+        ("undici", SinkSet::NETWORK),
+    ];
+    const PYTHON: &[(&str, SinkSet)] = &[
+        ("sqlalchemy", SinkSet::DATABASE),
+        ("django.db", SinkSet::DATABASE),
+        ("psycopg", SinkSet::DATABASE),
+        ("asyncpg", SinkSet::DATABASE),
+        ("requests", SinkSet::NETWORK),
+        ("httpx", SinkSet::NETWORK),
+        ("aiohttp", SinkSet::NETWORK),
+        ("urllib", SinkSet::NETWORK),
+    ];
+    const RUST: &[(&str, SinkSet)] = &[
+        ("sqlx", SinkSet::DATABASE),
+        ("diesel", SinkSet::DATABASE),
+        ("sea_orm", SinkSet::DATABASE),
+        ("reqwest", SinkSet::NETWORK),
+        ("hyper", SinkSet::NETWORK),
+    ];
+    const GO: &[(&str, SinkSet)] = &[
+        ("database/sql", SinkSet::DATABASE),
+        ("jmoiron/sqlx", SinkSet::DATABASE),
+        ("gorm.io/gorm", SinkSet::DATABASE),
+        ("net/http", SinkSet::NETWORK),
+    ];
+    match profile {
+        LanguageProfile::JavaScript | LanguageProfile::TypeScript | LanguageProfile::Tsx => JS,
+        LanguageProfile::Python => PYTHON,
+        LanguageProfile::Rust => RUST,
+        LanguageProfile::Go => GO,
+        _ => &[],
+    }
+}
+
+fn identifiers(value: &str) -> Vec<String> {
+    value
+        .split(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
+        .filter(|part| {
+            !part.is_empty()
+                && part
+                    .as_bytes()
+                    .first()
+                    .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_')
+        })
+        .map(str::to_owned)
+        .collect()
+}
+
+fn contains_package(source: &str, package: &str) -> bool {
+    source.match_indices(package).any(|(start, _)| {
+        let before = source[..start].chars().next_back();
+        let after = source[start + package.len()..].chars().next();
+        !before.is_some_and(package_identifier_character)
+            && !after.is_some_and(package_identifier_character)
+    })
+}
+
+fn package_identifier_character(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+}
+
+fn quoted_value(line: &str) -> Option<&str> {
+    for quote in ['\"', '\''] {
+        if let Some((_, rest)) = line.split_once(quote) {
+            if let Some((value, _)) = rest.split_once(quote) {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+fn without_strings(value: &str) -> String {
+    let mut quote = None;
+    value
+        .chars()
+        .map(|character| match quote {
+            Some(active) if character == active => {
+                quote = None;
+                ' '
+            }
+            Some(_) => ' ',
+            None if matches!(character, '\"' | '\'') => {
+                quote = Some(character);
+                ' '
+            }
+            None => character,
+        })
+        .collect()
+}
+
+fn binding_keywords() -> &'static [&'static str] {
+    &[
+        "as", "const", "from", "import", "let", "mut", "require", "use", "var",
+    ]
+}
+
+fn database_methods() -> &'static [&'static str] {
+    &[
+        "create",
+        "delete",
+        "execute",
+        "fetch",
+        "fetchall",
+        "fetchone",
+        "findfirst",
+        "findmany",
+        "findunique",
+        "insert",
+        "insertinto",
+        "open",
+        "query",
+        "save",
+        "update",
+    ]
+}
+
+fn network_methods() -> &'static [&'static str] {
+    &[
+        "delete", "fetch", "get", "patch", "post", "put", "request", "send",
+    ]
+}
+
+impl SemanticIndex {
+    fn build(files: &[std::path::PathBuf]) -> Self {
+        let mut index = Self::default();
+        let mut drafts = Vec::new();
+        let mut counts = HashMap::<String, usize>::new();
+        for path in files {
+            let Some(profile) =
+                LanguageProfile::from_path(path).filter(|profile| profile.has_semantic_pack())
+            else {
+                continue;
+            };
+            let Ok(source) = fs::read_to_string(path) else {
+                continue;
+            };
+            let mut provenance = FileProvenance::from_source(profile, &source);
+            let mut parser = Parser::new();
+            if parser.set_language(&profile.language()).is_err() {
+                continue;
+            }
+            let Some(tree) = parser
+                .parse(&source, None)
+                .filter(|tree| !tree.root_node().has_error())
+            else {
+                continue;
+            };
+            let draft_start = drafts.len();
+            collect_function_drafts(
+                tree.root_node(),
+                &source,
+                profile,
+                &provenance,
+                &mut drafts,
+                &mut counts,
+            );
+            provenance
+                .local_symbols
+                .extend(drafts[draft_start..].iter().map(|draft| draft.name.clone()));
+            index.files.insert(path.clone(), provenance);
+        }
+
+        for draft in &drafts {
+            if counts.get(&draft.name) == Some(&1) {
+                index.functions.insert(draft.name.clone(), draft.sinks);
+            }
+        }
+        for _ in 0..drafts.len().max(1) {
+            let mut changed = false;
+            // ponytail: project-wide fixed point is O(F × (F+E)); use SCC condensation if measured on huge projects
+            // forgeguard: allow FG-ALG-001 -- bounded by finite function/call graph and exits when no summary changes
+            for draft in &drafts {
+                if counts.get(&draft.name) != Some(&1) {
+                    continue;
+                }
+                let inherited = draft
+                    .calls
+                    .iter()
+                    .fold(SinkSet::default(), |mut sinks, call| {
+                        if let Some(summary) = index.functions.get(call) {
+                            sinks.insert(*summary);
+                        }
+                        sinks
+                    });
+                changed |= index
+                    .functions
+                    .entry(draft.name.clone())
+                    .or_default()
+                    .insert(inherited);
+            }
+            if !changed {
+                break;
+            }
+        }
+        index
+    }
+
+    fn classify(&self, path: &Path, callee: &str, method: &str) -> SinkSet {
+        let mut sinks = self
+            .files
+            .get(path)
+            .map(|provenance| provenance.classify(callee, method))
+            .unwrap_or_default();
+        let terminal = terminal_name(callee);
+        if self
+            .files
+            .get(path)
+            .is_some_and(|provenance| provenance.local_symbols.contains(terminal))
+        {
+            if let Some(summary) = self.functions.get(terminal) {
+                sinks.insert(*summary);
+            }
+        }
+        sinks
+    }
+}
+
 impl Analyzer {
     fn new() -> Result<Self> {
         Ok(Self {
@@ -302,7 +724,14 @@ impl Analyzer {
         Some((profile, mask_outside(source, &regions)))
     }
 
-    fn scan_file(&mut self, root: &Path, path: &Path, source: &str, findings: &mut Vec<Finding>) {
+    fn scan_file(
+        &mut self,
+        root: &Path,
+        path: &Path,
+        source: &str,
+        semantic: &SemanticIndex,
+        findings: &mut Vec<Finding>,
+    ) {
         let relative = path.strip_prefix(root).unwrap_or(path).to_path_buf();
         let component = self.extract_component_script(path, source);
         let (profile, source, emit_parse_errors) = match component.as_ref() {
@@ -362,6 +791,7 @@ impl Analyzer {
             if let Some(callee) = call_name(node, source) {
                 let in_loop = loop_depth > 0;
                 let method = terminal_name(callee);
+                let semantic_sinks = semantic.classify(path, callee, method);
                 if in_loop && profile.is_linear_lookup(method) {
                     findings.push(finding_for_node(
                         "FG-ALG-002",
@@ -373,7 +803,7 @@ impl Analyzer {
                         "Pre-index the lookup collection with a map or set when its size can grow.",
                     ));
                 }
-                if in_loop && is_database_call(callee, method) {
+                if in_loop && semantic_sinks.contains(SinkSet::DATABASE) {
                     findings.push(finding_for_node(
                         "FG-DB-001",
                         "Database operation inside iteration",
@@ -383,8 +813,18 @@ impl Analyzer {
                         source,
                         "Replace per-item database access with a set-based query, join, eager load, prefetch, or bulk operation.",
                     ));
+                } else if in_loop && is_database_call(callee, method) {
+                    findings.push(finding_for_node(
+                        "FG-DB-002",
+                        "Potential database operation inside iteration",
+                        Severity::Info,
+                        &relative,
+                        node,
+                        source,
+                        "Confirm receiver provenance. Batch the operation if it performs database I/O.",
+                    ));
                 }
-                if in_loop && is_network_call(callee, method) {
+                if in_loop && semantic_sinks.contains(SinkSet::NETWORK) {
                     findings.push(finding_for_node(
                         "FG-NET-001",
                         "External request inside iteration",
@@ -393,6 +833,16 @@ impl Analyzer {
                         node,
                         source,
                         "Use API batching or bounded concurrency with timeouts and partial-failure handling.",
+                    ));
+                } else if in_loop && is_network_call(callee, method) {
+                    findings.push(finding_for_node(
+                        "FG-NET-002",
+                        "Potential external request inside iteration",
+                        Severity::Info,
+                        &relative,
+                        node,
+                        source,
+                        "Confirm receiver provenance. Batch or bound concurrency if this performs network I/O.",
                     ));
                 }
                 if in_loop
@@ -527,6 +977,52 @@ enum LanguageProfile {
 }
 
 impl LanguageProfile {
+    fn family(self) -> &'static str {
+        match self {
+            Self::JavaScript | Self::TypeScript | Self::Tsx => "javascript",
+            Self::Rust => "rust",
+            Self::Go => "go",
+            Self::Python => "python",
+            Self::Java => "java",
+            Self::Kotlin => "kotlin",
+            Self::CSharp => "csharp",
+            Self::C => "c",
+            Self::Cpp => "cpp",
+            Self::Ruby => "ruby",
+            Self::Php => "php",
+            Self::Swift => "swift",
+            Self::Dart => "dart",
+            Self::Bash => "shell",
+            Self::Zig => "zig",
+            Self::Lua => "lua",
+            Self::Scala => "scala",
+            Self::Solidity => "solidity",
+            Self::Elixir => "elixir",
+            Self::Erlang => "erlang",
+            Self::RLang => "r",
+            Self::Hcl => "hcl",
+        }
+    }
+
+    fn has_semantic_pack(self) -> bool {
+        matches!(
+            self,
+            Self::JavaScript | Self::TypeScript | Self::Tsx | Self::Python | Self::Rust | Self::Go
+        )
+    }
+
+    fn is_function(self, kind: &str) -> bool {
+        match self {
+            Self::JavaScript | Self::TypeScript | Self::Tsx => {
+                matches!(kind, "function_declaration" | "method_definition")
+            }
+            Self::Python => kind == "function_definition",
+            Self::Rust => kind == "function_item",
+            Self::Go => matches!(kind, "function_declaration" | "method_declaration"),
+            _ => false,
+        }
+    }
+
     fn from_path(path: &Path) -> Option<Self> {
         match path.extension()?.to_str()? {
             "js" | "jsx" | "mjs" | "cjs" => Some(Self::JavaScript),
@@ -719,6 +1215,120 @@ impl LanguageProfile {
             _ => false,
         }
     }
+}
+
+pub(crate) struct CanonicalFunction {
+    pub profile: &'static str,
+    pub line: usize,
+    pub canonical: String,
+    pub original: String,
+}
+
+pub(crate) fn canonical_functions(
+    path: &Path,
+    source: &str,
+    minimum_lines: usize,
+) -> Vec<CanonicalFunction> {
+    let Some(profile) = LanguageProfile::from_path(path) else {
+        return Vec::new();
+    };
+    let mut parser = Parser::new();
+    if parser.set_language(&profile.language()).is_err() {
+        return Vec::new();
+    }
+    let Some(tree) = parser
+        .parse(source, None)
+        .filter(|tree| !tree.root_node().has_error())
+    else {
+        return Vec::new();
+    };
+    let mut functions = Vec::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        if is_clone_scope(node.kind())
+            && node.end_position().row + 1 >= node.start_position().row + minimum_lines
+        {
+            let mut identifiers = HashMap::new();
+            let mut canonical = String::new();
+            canonicalize_node(node, source, &mut identifiers, &mut canonical);
+            functions.push(CanonicalFunction {
+                profile: profile.family(),
+                line: node.start_position().row + 1,
+                canonical,
+                original: node_text(node, source)
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            });
+        } else {
+            stack.extend(
+                (0..node.named_child_count()).filter_map(|index| node.named_child(index as u32)),
+            );
+        }
+    }
+    functions
+}
+
+fn is_clone_scope(kind: &str) -> bool {
+    matches!(
+        kind,
+        "function_declaration"
+            | "function_definition"
+            | "function_item"
+            | "method"
+            | "method_declaration"
+            | "method_definition"
+            | "constructor_declaration"
+    )
+}
+
+fn canonicalize_node(
+    node: Node<'_>,
+    source: &str,
+    identifiers: &mut HashMap<String, usize>,
+    output: &mut String,
+) {
+    if node.kind().contains("comment") {
+        return;
+    }
+    output.push('(');
+    output.push_str(node.kind());
+    if node.child_count() == 0 {
+        output.push(':');
+        let text = node_text(node, source);
+        if is_local_identifier(node) {
+            let next = identifiers.len();
+            let id = *identifiers.entry(text.to_owned()).or_insert(next);
+            output.push('v');
+            output.push_str(&id.to_string());
+        } else {
+            output.push_str(text);
+        }
+    } else {
+        for index in 0..node.child_count() {
+            if let Some(child) = node.child(index as u32) {
+                canonicalize_node(child, source, identifiers, output);
+            }
+        }
+    }
+    output.push(')');
+}
+
+fn is_local_identifier(node: Node<'_>) -> bool {
+    if node.kind() != "identifier" && node.kind() != "simple_identifier" {
+        return false;
+    }
+    let Some(parent) = node.parent() else {
+        return true;
+    };
+    for field in ["field", "function", "method", "name", "property"] {
+        if parent.child_by_field_name(field) == Some(node)
+            && matches!(field, "field" | "function" | "method" | "property")
+        {
+            return false;
+        }
+    }
+    true
 }
 
 /// Blank every byte outside `regions` (non-newline → space, newline kept) so
@@ -979,6 +1589,10 @@ fn finding(
         rule_id: rule_id.to_owned(),
         title: title.to_owned(),
         severity,
+        confidence: rules::metadata(rule_id)
+            .map(|rule| rule.confidence)
+            .unwrap_or(EvidenceConfidence::Heuristic),
+        blocking: false,
         path: path.to_path_buf(),
         line,
         evidence: truncate(evidence, 240),

--- a/crates/forgeguard-core/tests/baseline_test.rs
+++ b/crates/forgeguard-core/tests/baseline_test.rs
@@ -1,11 +1,14 @@
 use std::fs;
 
 use forgeguard_core::{
-    create_baseline, run_gate, ForgeGuardConfig, GateOptions, GateStatus, GuardMode, BASELINE_FILE,
+    create_baseline, create_baseline_with_config, run_gate, ForgeGuardConfig, GateOptions,
+    GateStatus, GuardMode, BASELINE_FILE,
 };
 use tempfile::tempdir;
 
 const EXISTING_FINDING: &str = r#"
+import { PrismaClient } from "@prisma/client";
+const db = new PrismaClient();
 for (const user of users) {
   await db.query("SELECT id FROM profiles WHERE user_id = ?", [user.id]);
 }
@@ -19,7 +22,8 @@ fn baseline_hides_existing_finding_after_line_move() {
     let mut config = ForgeGuardConfig::new("sample", Vec::new());
     config.mode = GuardMode::Strict;
 
-    let baseline = create_baseline(directory.path(), &config.scan, false).expect("create baseline");
+    let baseline =
+        create_baseline_with_config(directory.path(), &config, false).expect("create baseline");
     assert_eq!(baseline.total_findings(), 1);
 
     fs::write(&source, format!("\n\n{EXISTING_FINDING}")).expect("move finding");
@@ -45,11 +49,13 @@ fn baseline_reports_additional_matching_finding() {
     fs::write(&source, EXISTING_FINDING).expect("write source");
     let mut config = ForgeGuardConfig::new("sample", Vec::new());
     config.mode = GuardMode::Strict;
-    create_baseline(directory.path(), &config.scan, false).expect("create baseline");
+    create_baseline_with_config(directory.path(), &config, false).expect("create baseline");
 
     fs::write(
         &source,
         r#"
+import { PrismaClient } from "@prisma/client";
+const db = new PrismaClient();
 for (const user of users) {
   await db.query("SELECT id FROM profiles WHERE user_id = ?", [user.id]);
   await db.query("SELECT id FROM profiles WHERE user_id = ?", [user.id]);

--- a/crates/forgeguard-core/tests/config_test.rs
+++ b/crates/forgeguard-core/tests/config_test.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use forgeguard_core::{CommandConfig, ForgeGuardConfig, GuardMode};
+use forgeguard_core::{CommandConfig, ForgeGuardConfig, GuardMode, Severity};
 use tempfile::tempdir;
 
 #[test]
@@ -27,6 +27,7 @@ fn configuration_round_trips_through_toml() {
 #[test]
 fn new_configuration_defaults_to_default_mode() {
     let config = ForgeGuardConfig::new("example", Vec::new());
+    assert_eq!(config.version, 2);
     assert_eq!(config.mode, GuardMode::Default);
     assert!(config.focus.enabled);
     assert_eq!(config.focus.max_retries, 3);
@@ -77,4 +78,79 @@ fn global_configuration_round_trips_through_toml() {
 
     assert_eq!(loaded, config);
     assert!(directory.path().join(".forgeguard/config.toml").exists());
+}
+
+#[test]
+fn config_v2_loads_global_and_per_rule_policy() {
+    let directory = tempdir().expect("temp directory");
+    fs::create_dir_all(directory.path().join(".forgeguard")).expect("create config dir");
+    fs::write(
+        directory.path().join(".forgeguard/config.toml"),
+        r#"version = 2
+mode = "strict"
+
+[project]
+name = "policy"
+
+[policies]
+warnings_block = false
+
+[rules.FG-NET-001]
+enabled = true
+severity = "error"
+block = true
+"#,
+    )
+    .expect("write config");
+
+    let config = ForgeGuardConfig::load(directory.path()).expect("load config");
+    assert_eq!(config.policies.warnings_block, Some(false));
+    let rule = config.rules.get("FG-NET-001").expect("rule policy");
+    assert_eq!(rule.enabled, Some(true));
+    assert_eq!(rule.severity, Some(Severity::Error));
+    assert_eq!(rule.block, Some(true));
+}
+
+#[test]
+fn migration_to_v2_preserves_commands_focus_and_mode() {
+    let mut config = ForgeGuardConfig::new(
+        "migration",
+        vec![CommandConfig {
+            name: "test".to_owned(),
+            command: "cargo test".to_owned(),
+            required: true,
+            enabled: true,
+            timeout_seconds: 45,
+        }],
+    );
+    config.version = 1;
+    config.mode = GuardMode::Strict;
+    config.focus.max_retries = 7;
+    let commands = config.commands.clone();
+    let focus = config.focus.clone();
+
+    assert_eq!(config.migrate_to_v2().expect("migrate config"), 1);
+    assert_eq!(config.version, 2);
+    assert_eq!(config.mode, GuardMode::Strict);
+    assert_eq!(config.commands, commands);
+    assert_eq!(config.focus, focus);
+    assert_eq!(config.migrate_to_v2().expect("idempotent migration"), 2);
+}
+
+#[test]
+fn unsupported_config_version_fails_closed() {
+    let directory = tempdir().expect("temp directory");
+    fs::create_dir_all(directory.path().join(".forgeguard")).expect("create config dir");
+    fs::write(
+        directory.path().join(".forgeguard/config.toml"),
+        r#"version = 99
+
+[project]
+name = "future"
+"#,
+    )
+    .expect("write config");
+
+    let error = ForgeGuardConfig::load(directory.path()).expect_err("reject unknown version");
+    assert!(error.to_string().contains("unsupported config version 99"));
 }

--- a/crates/forgeguard-core/tests/duplication_test.rs
+++ b/crates/forgeguard-core/tests/duplication_test.rs
@@ -86,3 +86,62 @@ end
         .iter()
         .any(|finding| finding.rule_id == "FG-DRY-001"));
 }
+
+#[test]
+fn reports_alpha_renamed_functions_but_preserves_literals() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("customer.rs"),
+        r#"pub fn customer_score(users: &[i32]) -> i32 {
+    let mut total = 0;
+    for user in users {
+        let adjusted = user * 2;
+        total += adjusted;
+    }
+    total
+}
+"#,
+    )
+    .expect("write first source");
+    fs::write(
+        directory.path().join("account.rs"),
+        r#"pub fn account_score(accounts: &[i32]) -> i32 {
+    let mut sum = 0;
+    for account in accounts {
+        let weighted = account * 2;
+        sum += weighted;
+    }
+    sum
+}
+"#,
+    )
+    .expect("write renamed source");
+    fs::write(
+        directory.path().join("different.rs"),
+        r#"pub fn different_score(accounts: &[i32]) -> i32 {
+    let mut sum = 0;
+    for account in accounts {
+        let weighted = account * 3;
+        sum += weighted;
+    }
+    sum
+}
+"#,
+    )
+    .expect("write different source");
+
+    let findings = scan_project(
+        directory.path(),
+        &ScanConfig::default(),
+        &ScanOptions::default(),
+    )
+    .expect("scan project");
+
+    assert!(findings
+        .iter()
+        .any(|finding| finding.rule_id == "FG-DRY-002"));
+    assert!(!findings.iter().any(|finding| {
+        finding.rule_id == "FG-DRY-002"
+            && finding.path.as_path() == std::path::Path::new("different.rs")
+    }));
+}

--- a/crates/forgeguard-core/tests/gate_test.rs
+++ b/crates/forgeguard-core/tests/gate_test.rs
@@ -1,6 +1,8 @@
 use std::fs;
 
-use forgeguard_core::{run_gate, ForgeGuardConfig, GateOptions, GateStatus, GuardMode};
+use forgeguard_core::{
+    config::RuleConfig, run_gate, ForgeGuardConfig, GateOptions, GateStatus, GuardMode, Severity,
+};
 use tempfile::tempdir;
 
 #[test]
@@ -9,6 +11,8 @@ fn default_mode_reports_static_findings_without_blocking() {
     fs::write(
         directory.path().join("repository.ts"),
         r#"
+import { PrismaClient } from "@prisma/client";
+const db = new PrismaClient();
 for (const user of users) {
   await db.query("SELECT id FROM profiles WHERE user_id = ?", [user.id]);
 }
@@ -36,6 +40,8 @@ fn strict_mode_blocks_error_level_findings() {
     fs::write(
         directory.path().join("repository.ts"),
         r#"
+import { PrismaClient } from "@prisma/client";
+const db = new PrismaClient();
 for (const user of users) {
   await db.query("SELECT id FROM profiles WHERE user_id = ?", [user.id]);
 }
@@ -106,6 +112,87 @@ fn explicit_empty_path_scope_scans_nothing() {
     )
     .expect("run gate");
 
+    assert_eq!(report.status, GateStatus::Passed);
+    assert!(report.findings.is_empty());
+}
+
+#[test]
+fn config_v2_strict_blocks_warnings_but_v1_keeps_error_only_behavior() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("nested.ts"),
+        "for (const row of rows) { for (const value of row) { console.log(value); } }\n",
+    )
+    .expect("write source");
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = GuardMode::Strict;
+
+    let report = run_gate(
+        directory.path(),
+        &config,
+        &GateOptions {
+            skip_commands: true,
+            paths: None,
+        },
+    )
+    .expect("run v2 gate");
+    assert_eq!(report.status, GateStatus::Blocked);
+    assert_eq!(report.summary.blocking_findings, 1);
+
+    config.version = 1;
+    let report = run_gate(
+        directory.path(),
+        &config,
+        &GateOptions {
+            skip_commands: true,
+            paths: None,
+        },
+    )
+    .expect("run v1 gate");
+    assert_eq!(report.status, GateStatus::Warning);
+    assert_eq!(report.summary.blocking_findings, 0);
+}
+
+#[test]
+fn per_rule_policy_can_disable_override_and_block() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("nested.ts"),
+        "for (const row of rows) { for (const value of row) { console.log(value); } }\n",
+    )
+    .expect("write source");
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.rules.insert(
+        "FG-ALG-001".to_owned(),
+        RuleConfig {
+            enabled: None,
+            severity: Some(Severity::Error),
+            block: Some(true),
+        },
+    );
+
+    let report = run_gate(
+        directory.path(),
+        &config,
+        &GateOptions {
+            skip_commands: true,
+            paths: None,
+        },
+    )
+    .expect("run configured gate");
+    assert_eq!(report.status, GateStatus::Blocked);
+    assert_eq!(report.findings[0].severity, Severity::Error);
+
+    config.rules.get_mut("FG-ALG-001").expect("rule").enabled = Some(false);
+    let report = run_gate(
+        directory.path(),
+        &config,
+        &GateOptions {
+            skip_commands: true,
+            paths: None,
+        },
+    )
+    .expect("run disabled gate");
     assert_eq!(report.status, GateStatus::Passed);
     assert!(report.findings.is_empty());
 }

--- a/crates/forgeguard-core/tests/hook_test.rs
+++ b/crates/forgeguard-core/tests/hook_test.rs
@@ -19,7 +19,7 @@ fn blocked_hook_is_compact_cached_and_bounded() {
     for index in 0..40 {
         fs::write(
             directory.path().join(format!("repository-{index}.ts")),
-            "for (const user of users) { await db.query('SELECT id FROM users'); }\n",
+            "import { PrismaClient } from '@prisma/client';\nconst db = new PrismaClient();\nfor (const user of users) { await db.query('SELECT id FROM users'); }\n",
         )
         .expect("write source");
     }
@@ -438,7 +438,7 @@ fn stop_retry_budget_is_isolated_by_session() {
     config.save(directory.path()).expect("save config");
     fs::write(
         directory.path().join("service.ts"),
-        "for (const user of users) { await db.query('SELECT id FROM users'); }\n",
+        "import { PrismaClient } from '@prisma/client';\nconst db = new PrismaClient();\nfor (const user of users) { await db.query('SELECT id FROM users'); }\n",
     )
     .expect("write source");
     let input = |session: &str| {
@@ -471,7 +471,7 @@ fn cursor_transcript_path_isolates_retry_budget_without_a_session_id() {
     config.save(directory.path()).expect("save config");
     fs::write(
         directory.path().join("service.ts"),
-        "for (const user of users) { await db.query('SELECT id FROM users'); }\n",
+        "import { PrismaClient } from '@prisma/client';\nconst db = new PrismaClient();\nfor (const user of users) { await db.query('SELECT id FROM users'); }\n",
     )
     .expect("write source");
     let input = |transcript: &str| {
@@ -525,7 +525,7 @@ fn auto_gate_reports_without_blocking_without_config_and_ignores_artifacts() {
     fs::write(directory.path().join(".gitignore"), "node_modules/\n").expect("write gitignore");
     fs::write(
         directory.path().join("service.ts"),
-        "for (const user of users) { await db.query('SELECT id FROM users WHERE id = 1'); }\n",
+        "import { PrismaClient } from '@prisma/client';\nconst db = new PrismaClient();\nfor (const user of users) { await db.query('SELECT id FROM users WHERE id = 1'); }\n",
     )
     .expect("write source");
 

--- a/crates/forgeguard-core/tests/report_test.rs
+++ b/crates/forgeguard-core/tests/report_test.rs
@@ -1,0 +1,46 @@
+use std::fs;
+
+use forgeguard_core::{report::render_sarif, run_gate, ForgeGuardConfig, GateOptions, GuardMode};
+use tempfile::tempdir;
+
+#[test]
+fn sarif_contains_rule_location_confidence_and_blocking_state() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("repository.ts"),
+        r#"import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+for (const id of ids) { prisma.user.findMany({ where: { id } }); }
+"#,
+    )
+    .expect("write source");
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = GuardMode::Strict;
+    let report = run_gate(
+        directory.path(),
+        &config,
+        &GateOptions {
+            skip_commands: true,
+            paths: None,
+        },
+    )
+    .expect("run gate");
+
+    let sarif: serde_json::Value =
+        serde_json::from_str(&render_sarif(&report).expect("render SARIF")).expect("parse SARIF");
+    assert_eq!(sarif["version"], "2.1.0");
+    assert_eq!(sarif["runs"][0]["results"][0]["ruleId"], "FG-DB-001");
+    assert_eq!(
+        sarif["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]
+            ["uri"],
+        "repository.ts"
+    );
+    assert_eq!(
+        sarif["runs"][0]["results"][0]["properties"]["confidence"],
+        "semantic"
+    );
+    assert_eq!(
+        sarif["runs"][0]["results"][0]["properties"]["blocking"],
+        true
+    );
+}

--- a/crates/forgeguard-core/tests/scanner_test.rs
+++ b/crates/forgeguard-core/tests/scanner_test.rs
@@ -37,7 +37,7 @@ export async function enrich(users, roles, db) {
         .any(|finding| finding.rule_id == "FG-ALG-002"));
     assert!(findings
         .iter()
-        .any(|finding| { finding.rule_id == "FG-DB-001" && finding.severity == Severity::Error }));
+        .any(|finding| { finding.rule_id == "FG-DB-002" && finding.severity == Severity::Info }));
 }
 
 #[test]
@@ -118,7 +118,7 @@ async def load_profiles(users, db):
         .any(|finding| finding.rule_id == "FG-ALG-001"));
     assert!(findings
         .iter()
-        .any(|finding| finding.rule_id == "FG-DB-001"));
+        .any(|finding| finding.rule_id == "FG-DB-002"));
 }
 
 #[test]
@@ -194,6 +194,8 @@ fn detects_chained_orm_query_inside_loop() {
     fs::write(
         directory.path().join("repository.ts"),
         r#"
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
 for (const account of accounts) {
   await prisma.user.findMany({ where: { accountId: account.id } });
 }
@@ -278,7 +280,7 @@ fn detects_database_access_in_rust_go_and_python_loops() {
     .expect("scan project");
 
     for path in ["repository.rs", "repository.go", "repository.py"] {
-        assert!(findings.iter().any(|finding| finding.rule_id == "FG-DB-001"
+        assert!(findings.iter().any(|finding| finding.rule_id == "FG-DB-002"
             && finding.path.as_path() == std::path::Path::new(path)));
     }
 }
@@ -559,7 +561,7 @@ fn detects_database_calls_in_common_object_oriented_languages() {
     for (name, _) in sources {
         assert!(
             findings.iter().any(|finding| {
-                finding.rule_id == "FG-DB-001"
+                finding.rule_id == "FG-DB-002"
                     && finding.path.as_path() == std::path::Path::new(name)
             }),
             "missing database-in-loop finding for {name}"
@@ -618,6 +620,8 @@ fn reasoned_inline_suppression_only_hides_heuristics() {
     fs::write(
         directory.path().join("service.ts"),
         r#"
+import { PrismaClient } from "@prisma/client";
+const db = new PrismaClient();
 for (const user of users) {
   // forgeguard: allow FG-ALG-002 -- roles has a documented maximum of 4
   const role = roles.find((candidate) => candidate.id === user.roleId);
@@ -676,7 +680,7 @@ fn scans_svelte_component_script_with_correct_line_numbers() {
 
     let db = findings
         .iter()
-        .find(|finding| finding.rule_id == "FG-DB-001" && finding.severity == Severity::Error)
+        .find(|finding| finding.rule_id == "FG-DB-002" && finding.severity == Severity::Info)
         .expect("db-in-loop flagged inside svelte <script>");
     // The db.query call sits on line 6 of the original file; masking must
     // preserve line numbers so the finding points back at the real source.
@@ -764,4 +768,116 @@ fn flags_large_inline_data_literal_but_not_small_one() {
         .iter()
         .any(|finding| finding.rule_id == "FG-ARCH-001"
             && finding.path.to_string_lossy().ends_with("small.ts")));
+}
+
+#[test]
+fn semantic_packs_propagate_database_and_network_wrappers() {
+    let directory = tempdir().expect("temp directory");
+    let sources = [
+        (
+            "service.ts",
+            r#"import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+async function loadUser(id) { return prisma.user.findMany({ where: { id } }); }
+for (const id of ids) { await loadUser(id); }
+"#,
+            "FG-DB-001",
+        ),
+        (
+            "service.py",
+            "import requests as http\ndef fetch_user(url):\n    return http.get(url)\nfor url in urls:\n    fetch_user(url)\n",
+            "FG-NET-001",
+        ),
+        (
+            "service.rs",
+            "use sqlx;\nfn load_user(id: i64) { sqlx::query(\"SELECT id FROM users\"); }\nfn run(ids: &[i64]) { for id in ids { load_user(*id); } }\n",
+            "FG-DB-001",
+        ),
+        (
+            "service.go",
+            "package service\nimport \"net/http\"\nfunc fetchUser(url string) { http.Get(url) }\nfunc run(urls []string) { for _, url := range urls { fetchUser(url) } }\n",
+            "FG-NET-001",
+        ),
+    ];
+    for (name, source, _) in sources {
+        fs::write(directory.path().join(name), source).expect("write semantic source");
+    }
+
+    let findings = scan_project(
+        directory.path(),
+        &ScanConfig::default(),
+        &ScanOptions::default(),
+    )
+    .expect("scan project");
+
+    for (name, _, rule_id) in sources {
+        assert!(
+            findings.iter().any(|finding| {
+                finding.rule_id == rule_id && finding.path.as_path() == std::path::Path::new(name)
+            }),
+            "missing semantic finding {rule_id} for {name}"
+        );
+    }
+}
+
+#[test]
+fn receiver_name_collision_is_only_heuristic_evidence() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("memory.ts"),
+        r#"import fakeAxios from "not-axios";
+const local = "axios";
+for (const id of ids) { repository.findMany(id); client.get(id); fakeAxios.get(id); local.get(id); }
+"#,
+    )
+    .expect("write source");
+
+    let findings = scan_project(
+        directory.path(),
+        &ScanConfig::default(),
+        &ScanOptions::default(),
+    )
+    .expect("scan project");
+
+    assert!(!findings
+        .iter()
+        .any(|finding| { matches!(finding.rule_id.as_str(), "FG-DB-001" | "FG-NET-001") }));
+    assert!(findings
+        .iter()
+        .any(|finding| finding.rule_id == "FG-DB-002"));
+    assert!(findings
+        .iter()
+        .any(|finding| finding.rule_id == "FG-NET-002"));
+}
+
+#[test]
+fn changed_scope_resolves_wrapper_from_unchanged_file() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("database.ts"),
+        r#"import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+export async function loadUser(id) { return prisma.user.findMany({ where: { id } }); }
+"#,
+    )
+    .expect("write unchanged wrapper");
+    fs::write(
+        directory.path().join("service.ts"),
+        "import { loadUser } from './database';\nfor (const id of ids) { await loadUser(id); }\n",
+    )
+    .expect("write changed caller");
+
+    let findings = scan_project(
+        directory.path(),
+        &ScanConfig::default(),
+        &ScanOptions {
+            paths: Some(vec![std::path::PathBuf::from("service.ts")]),
+        },
+    )
+    .expect("scan changed file");
+
+    assert!(findings.iter().any(|finding| {
+        finding.rule_id == "FG-DB-001"
+            && finding.path.as_path() == std::path::Path::new("service.ts")
+    }));
 }

--- a/crates/forgeguard-core/tests/semantic_benchmark_test.rs
+++ b/crates/forgeguard-core/tests/semantic_benchmark_test.rs
@@ -1,0 +1,186 @@
+use std::fs;
+
+use forgeguard_core::{config::ScanConfig, scan_project, ScanOptions};
+use tempfile::tempdir;
+
+const LABELS_PER_CELL: usize = 20;
+
+#[test]
+fn semantic_packs_meet_fixture_precision_and_recall_floor() {
+    let cells = [
+        Cell::new(
+            "typescript-db",
+            "ts",
+            "import { PrismaClient } from \"@prisma/client\";\nconst prisma = new PrismaClient();\n",
+            "prisma.user.findMany({})",
+            "repository.findMany(id)",
+            "FG-DB-001",
+        ),
+        Cell::new(
+            "typescript-network",
+            "ts",
+            "import axios from \"axios\";\n",
+            "axios.get(String(id))",
+            "client.get(id)",
+            "FG-NET-001",
+        ),
+        Cell::new(
+            "python-db",
+            "py",
+            "from sqlalchemy.orm import Session\nsession = Session()\n",
+            "session.execute(id)",
+            "repository.findMany(id)",
+            "FG-DB-001",
+        ),
+        Cell::new(
+            "python-network",
+            "py",
+            "import requests\n",
+            "requests.get(str(id))",
+            "client.get(id)",
+            "FG-NET-001",
+        ),
+        Cell::new(
+            "rust-db",
+            "rs",
+            "use sqlx;\n",
+            "sqlx::query(\"SELECT 1\")",
+            "repository.find_many(id)",
+            "FG-DB-001",
+        ),
+        Cell::new(
+            "rust-network",
+            "rs",
+            "use reqwest;\n",
+            "reqwest::get(id)",
+            "client.get(id)",
+            "FG-NET-001",
+        ),
+        Cell::new(
+            "go-db",
+            "go",
+            "package benchmark\nimport \"database/sql\"\n",
+            "sql.Open(\"sqlite\", id)",
+            "repository.FindMany(id)",
+            "FG-DB-001",
+        ),
+        Cell::new(
+            "go-network",
+            "go",
+            "package benchmark\nimport \"net/http\"\n",
+            "http.Get(id)",
+            "client.Get(id)",
+            "FG-NET-001",
+        ),
+    ];
+
+    for cell in cells {
+        let directory = tempdir().expect("temp directory");
+        fs::write(
+            directory
+                .path()
+                .join(format!("positive.{}", cell.extension)),
+            cell.source(cell.positive),
+        )
+        .expect("write positive corpus");
+        fs::write(
+            directory
+                .path()
+                .join(format!("negative.{}", cell.extension)),
+            cell.source(cell.negative),
+        )
+        .expect("write negative corpus");
+
+        let findings = scan_project(
+            directory.path(),
+            &ScanConfig::default(),
+            &ScanOptions::default(),
+        )
+        .expect("scan benchmark corpus");
+        let true_positives = findings
+            .iter()
+            .filter(|finding| {
+                finding.rule_id == cell.rule
+                    && finding.path.to_string_lossy().starts_with("positive")
+            })
+            .count();
+        let false_positives = findings
+            .iter()
+            .filter(|finding| {
+                finding.rule_id == cell.rule
+                    && finding.path.to_string_lossy().starts_with("negative")
+            })
+            .count();
+        let false_negatives = LABELS_PER_CELL.saturating_sub(true_positives);
+        let precision = ratio(true_positives, true_positives + false_positives);
+        let recall = ratio(true_positives, true_positives + false_negatives);
+
+        assert!(precision >= 0.95, "{} precision {precision:.3}", cell.name);
+        assert!(recall >= 0.85, "{} recall {recall:.3}", cell.name);
+    }
+}
+
+struct Cell {
+    name: &'static str,
+    extension: &'static str,
+    prelude: &'static str,
+    positive: &'static str,
+    negative: &'static str,
+    rule: &'static str,
+}
+
+impl Cell {
+    const fn new(
+        name: &'static str,
+        extension: &'static str,
+        prelude: &'static str,
+        positive: &'static str,
+        negative: &'static str,
+        rule: &'static str,
+    ) -> Self {
+        Self {
+            name,
+            extension,
+            prelude,
+            positive,
+            negative,
+            rule,
+        }
+    }
+
+    fn source(&self, call: &str) -> String {
+        let calls = (0..LABELS_PER_CELL)
+            .map(|_| format!("{call};"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        match self.extension {
+            "py" => format!(
+                "{}for id in ids:\n{}\n",
+                self.prelude,
+                calls
+                    .split(';')
+                    .filter(|line| !line.is_empty())
+                    .map(|line| format!("    {line}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ),
+            "rs" => format!(
+                "{}fn run(ids: &[&str]) {{ for id in ids {{ {calls} }} }}\n",
+                self.prelude
+            ),
+            "go" => format!(
+                "{}func run(ids []string) {{ for _, id := range ids {{ {calls} }} }}\n",
+                self.prelude
+            ),
+            _ => format!("{}for (const id of ids) {{ {calls} }}\n", self.prelude),
+        }
+    }
+}
+
+fn ratio(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        1.0
+    } else {
+        numerator as f64 / denominator as f64
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@ ForgeGuard is split into two crates:
 - `forgeguard-core`: project detection, configuration, initialization, scanning, command execution, health checks, and reporting.
 - `forgeguard`: the CLI interface and exit-code policy.
 
-Rules, skills, hooks, and configured repository commands are language-agnostic. Parser-backed findings are an additional evidence layer, not the boundary of ForgeGuard support.
+Workflow rules, skills, hooks, and configured repository commands are language-agnostic. Parser, structural-rule, and semantic-pack support are separate capability tiers exposed by `forgeguard capabilities`.
 
 ## Execution flow
 
@@ -34,18 +34,19 @@ Full reports stay local under `.forgeguard/reports/`; per-session task and hook 
 
 ## Scanner design
 
-Tree-sitter provides syntax and loop scope for JavaScript, TypeScript, TSX, Rust, Go, Python, Java, Kotlin, C#, C, C++, Ruby, PHP, Swift, Dart, and Shell. Call classification stays conservative and only examines actual call nodes. Files with syntax errors receive `FG-PARSE-001` and no structural claims.
+Tree-sitter provides syntax, call nodes, loop scope, source locations, and code/comment separation across the parser matrix. JavaScript/TypeScript, Python, Rust, and Go add bounded import/binding provenance and fixed-point summaries for uniquely named local wrappers. Dynamic imports, reflection, macros, overload/type resolution, and runtime dispatch remain unresolved. Files with syntax errors receive `FG-PARSE-001` and no structural claims.
 
-Unsupported languages receive exact duplicate-block checks only; standalone SQL files also receive the `SELECT *` check. ForgeGuard deliberately reports evidence rather than pretending to prove whole-program complexity or runtime cost.
+Parser-backed function scopes also receive alpha-renamed Type-2 clone evidence; unsupported languages retain exact duplicate-block checks. Standalone SQL files receive the `SELECT *` check. ForgeGuard deliberately reports evidence rather than pretending to prove whole-program complexity or runtime cost.
 
 Source walking honors Git ignore files and excludes generated or dependency directories. Files larger than the configured limit are skipped.
 
 ## Gate policy
 
 - Required command failures always block.
-- Guard mode blocks error-level findings.
-- Strict mode blocks warning- and error-level findings.
+- Default mode blocks only explicitly configured static rules.
+- Strict config v2 blocks warning- and error-level findings; config v1 retains error-only compatibility until migration.
 - Lite mode reports static findings without blocking.
+- Per-rule `enabled`, `severity`, and `block` overrides apply before gate status.
 - Each configured command has a timeout; timeout is a failed check.
 - Duplicate rule/path/line findings collapse before rendering.
 
@@ -65,4 +66,4 @@ Source walking honors Git ignore files and excludes generated or dependency dire
 
 ## Extension direction
 
-Future packs should implement a stable rule trait and produce the same `Finding` model. Planned work includes SARIF output, deeper data-flow rules, MCP schema verification, and query-plan capture.
+Rule metadata has one registry and every finding carries confidence plus effective blocking state. SARIF 2.1.0 maps the same report model to code-scanning results. Future work includes compiler-backed type/data-flow packs, MCP schema verification, query-plan capture, SBOM, artifact signing, and provenance attestations.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,10 +24,16 @@
 - Session-scoped objectives, todo/confidence state, deterministic hill-climbability, bounded retry/no-progress handling, context restoration, declared-scope warnings, and default-on auto-poke verification phases.
 - Cross-platform release binaries and checksum-verifying installers.
 
+## 0.8 — Policy, semantic evidence, and security hardening
+
+- Config v2 per-rule enablement, severity, and blocking policy with v1 compatibility.
+- Bounded database/network provenance packs for JavaScript/TypeScript, Python, Rust, and Go.
+- Published capability matrix, labeled precision/recall gate, Type-2 clone evidence, and SARIF 2.1.0.
+- `cargo-deny`, `cargo-audit`, SHA-pinned actions, and Dependabot.
+
 ## Next — Database and AI packs
 
-- Function-level data-flow and complexity analysis.
-- SARIF output.
+- Compiler-backed type/data-flow and complexity analysis.
 - MCP schema verification.
 - Query-plan evidence collection.
 - AI tool schema, agent-loop, RAG, token, and evaluation gates.

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -14,7 +14,11 @@ Heuristic warning for repeated sorting. Consider one-time sorting, an ordered st
 
 ## FG-DB-001 — Database operation inside iteration
 
-Error-level rule for database-looking operations inside an active loop. Prefer set-based queries, joins, eager loading, prefetch, or bulk operations.
+Error-level rule for a provenance-confirmed database operation inside an active loop. JavaScript/TypeScript, Python, Rust, and Go packs resolve supported imports, lexical aliases, and unique local wrapper summaries.
+
+## FG-DB-002 — Potential database operation inside iteration
+
+Informational name-based fallback. Receiver names alone never produce the semantic-confirmed rule.
 
 ## FG-DB-005 — Potential unnecessary SELECT *
 
@@ -22,7 +26,11 @@ Warns when a query selects every column. Confirm whether all columns are require
 
 ## FG-NET-001 — External request inside iteration
 
-Warns when common HTTP-client calls are executed inside a loop. Prefer batching or bounded concurrency with timeout, rate-limit handling, retry classification, and partial-failure behavior.
+Warns when a provenance-confirmed HTTP-client call is executed inside a loop. Prefer batching or bounded concurrency with timeout, rate-limit handling, retry classification, and partial-failure behavior.
+
+## FG-NET-002 — Potential external request inside iteration
+
+Informational name-based fallback for unresolved receivers such as a generic `client`.
 
 ## FG-CON-001 — Potential unbounded parallel execution
 
@@ -32,13 +40,17 @@ Warns on common fan-out patterns such as `Promise.all(collection.map(...))` and 
 
 Informational cross-file duplicate block signal. Extract only when the duplicated code represents the same responsibility and should evolve together.
 
+## FG-DRY-002 — Potential renamed duplicated implementation
+
+Informational same-language function clone with local identifiers alpha-normalized. Operators, literals, member names, and imported API names remain significant. This is Type-2 clone evidence, not semantic business-logic equivalence.
+
 ## FG-PARSE-001 — Structural analysis skipped
 
 Informational finding for supported files containing syntax errors or an unavailable grammar. ForgeGuard skips structural claims for that file instead of falling back to noisy lexical guesses.
 
 ## False positives
 
-ForgeGuard rules are evidence for review, not permission to refactor blindly. Structural scope proves code placement, not runtime cost or business intent. Configure narrow exclusions or use Lite/Guard mode while the analyzer evolves. Strict mode is intended for repositories that have reviewed their warning baseline.
+ForgeGuard rules are evidence for review, not permission to refactor blindly. Structural scope and bounded provenance do not prove runtime cost or business intent. Configure per-rule policy, narrow exclusions, or Lite mode while reviewing a baseline. Strict v2 blocks Warning and Error findings.
 
 A reviewed heuristic can be suppressed on its line or the preceding line with a required reason:
 


### PR DESCRIPTION
## Summary
- add config v2 per-rule enforcement and compatibility migration
- add bounded semantic evidence, Type-2 clone detection, capability reporting, and SARIF
- harden CI supply-chain checks and release dependencies

## Validation
- cargo test --locked --workspace: 94 passed across 17 suites
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo build --locked --workspace --release
- cargo deny check
- cargo audit --deny warnings
- forgeguard gate --changed --output compact