### PR TITLE
Gate nested Git workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]

--- a/crates/forgeguard-core/src/doctor.rs
+++ b/crates/forgeguard-core/src/doctor.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     config::{ForgeGuardConfig, CONFIG_FILE},
+    git::repository_roots,
     init::{
         ANTIGRAVITY_CONTEXT_HOOK_COMMAND, ANTIGRAVITY_HOOK_COMMAND, ANTIGRAVITY_SCOPE_HOOK_COMMAND,
         CLAUDE_CONTEXT_HOOK_COMMAND, CLAUDE_HOOK_COMMAND, CLAUDE_SCOPE_HOOK_COMMAND,
@@ -45,7 +46,7 @@ pub struct HookStatus {
 
 pub fn run_doctor(root: &Path, config: Option<&ForgeGuardConfig>) -> Result<DoctorReport> {
     let configuration_found = root.join(CONFIG_FILE).exists();
-    let git_repository = root.join(".git").exists();
+    let git_repository = !repository_roots(root)?.is_empty();
     let mut tool_names = vec!["git".to_owned()];
     if let Some(config) = config {
         for command in &config.commands {

--- a/crates/forgeguard-core/src/git.rs
+++ b/crates/forgeguard-core/src/git.rs
@@ -1,12 +1,62 @@
 use std::{
-    fs::File,
+    fs::{self, File},
     hash::Hasher,
     io::Read,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, Output},
 };
 
 use anyhow::{bail, Context, Result};
+
+pub fn repository_roots(root: &Path) -> Result<Vec<PathBuf>> {
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("failed to resolve workspace root {}", root.display()))?;
+    if root.join(".git").exists() {
+        return Ok(vec![root]);
+    }
+
+    let mut pending = vec![root];
+    let mut repositories = Vec::new();
+    // ponytail: scan directories once until Git roots; add configurable bounds only if discovery becomes measurable.
+    while let Some(directory) = pending.pop() {
+        let entries = match fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        // forgeguard: allow FG-ALG-001 -- each directory entry is visited once; repository trees are not traversed
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+                continue;
+            }
+            if path.join(".git").exists() {
+                repositories.push(path);
+                continue;
+            }
+            if matches!(
+                entry.file_name().to_str(),
+                Some(
+                    ".git"
+                        | ".forgeguard"
+                        | "target"
+                        | "node_modules"
+                        | "vendor"
+                        | ".venv"
+                        | "venv"
+                        | "dist"
+                        | "build"
+                        | ".next"
+                )
+            ) {
+                continue;
+            }
+            pending.push(path);
+        }
+    }
+    repositories.sort();
+    Ok(repositories)
+}
 
 pub fn changed_files(root: &Path) -> Result<Vec<std::path::PathBuf>> {
     let output = status_output(root)?;

--- a/crates/forgeguard-core/src/hook.rs
+++ b/crates/forgeguard-core/src/hook.rs
@@ -12,7 +12,8 @@ use serde_json::{json, Value};
 use crate::{
     config::{FocusConfig, ForgeGuardConfig, GuardMode, CONFIG_FILE},
     detect_project,
-    git::{changed_files, worktree_fingerprint},
+    git::{changed_files, repository_roots, worktree_fingerprint},
+    model::GateSummary,
     report::{render_gate_compact, COMPACT_MAX_CHARS},
     run_gate, GateOptions, GateStatus,
 };
@@ -127,9 +128,13 @@ pub fn evaluate_stop_hook(fallback_root: &Path, input: &str) -> Result<(HookDeci
     let Some(root) = find_project_root(fallback_root, &payload) else {
         return Ok((HookDecision::Pass, false));
     };
+    let repositories = repository_roots(&root)?;
+    if repositories.is_empty() {
+        return Ok((HookDecision::Pass, false));
+    }
     let session = session_key(&payload);
     let mut task = read_task(&root, &session)?;
-    let worktree = worktree_fingerprint(&root)?;
+    let worktree = workspace_fingerprint(&root, &repositories)?;
     if worktree.is_none() {
         match task.as_ref().map(|task| task.status) {
             None | Some(TaskStatus::Completed | TaskStatus::Blocked) => {
@@ -201,14 +206,7 @@ pub fn evaluate_stop_hook(fallback_root: &Path, input: &str) -> Result<(HookDeci
             false,
         );
     }
-    let report = run_gate(
-        &root,
-        &config,
-        &GateOptions {
-            skip_commands: false,
-            paths: Some(changed_files(&root)?),
-        },
-    )?;
+    let report = run_workspace_gate(&root, &repositories, &config)?;
     write_json(&root.join(REPORT_FILE), &report)?;
     if report.status == GateStatus::Blocked {
         return bounded_block(
@@ -629,6 +627,116 @@ fn find_project_root(fallback_root: &Path, payload: &Value) -> Option<PathBuf> {
             .find(|path| path.join(".git").exists() || path.join(CONFIG_FILE).is_file())
             .map(Path::to_path_buf)
     })
+}
+
+fn workspace_fingerprint(workspace: &Path, repositories: &[PathBuf]) -> Result<Option<String>> {
+    if repositories == [workspace] {
+        return worktree_fingerprint(workspace);
+    }
+
+    let mut hasher = DefaultHasher::new();
+    let mut changed = false;
+    for repository in repositories {
+        let Some(fingerprint) = worktree_fingerprint(repository)? else {
+            continue;
+        };
+        changed = true;
+        hasher.write(
+            repository
+                .strip_prefix(workspace)
+                .unwrap_or(repository)
+                .to_string_lossy()
+                .as_bytes(),
+        );
+        hasher.write(fingerprint.as_bytes());
+    }
+    Ok(changed.then(|| format!("{:016x}", hasher.finish())))
+}
+
+fn run_workspace_gate(
+    workspace: &Path,
+    repositories: &[PathBuf],
+    workspace_config: &ForgeGuardConfig,
+) -> Result<crate::GateReport> {
+    if repositories == [workspace] {
+        return run_gate(
+            workspace,
+            workspace_config,
+            &GateOptions {
+                skip_commands: false,
+                paths: Some(changed_files(workspace)?),
+            },
+        );
+    }
+
+    let mut combined = crate::GateReport {
+        status: GateStatus::Passed,
+        findings: Vec::new(),
+        checks: Vec::new(),
+        summary: GateSummary {
+            errors: 0,
+            warnings: 0,
+            info: 0,
+            blocking_findings: 0,
+            findings_baselined: 0,
+            checks_passed: 0,
+            checks_failed: 0,
+        },
+    };
+    for repository in repositories {
+        if worktree_fingerprint(repository)?.is_none() {
+            continue;
+        }
+        let configured = repository.join(CONFIG_FILE).is_file();
+        let Some(mut config) = load_hook_config(repository)? else {
+            continue;
+        };
+        if !configured {
+            config.version = workspace_config.version;
+            config.mode = workspace_config.mode;
+            config.scan = workspace_config.scan.clone();
+            config.policies = workspace_config.policies.clone();
+            config.rules = workspace_config.rules.clone();
+        }
+        let report = run_gate(
+            repository,
+            &config,
+            &GateOptions {
+                skip_commands: false,
+                paths: Some(changed_files(repository)?),
+            },
+        )?;
+        write_json(&repository.join(REPORT_FILE), &report)?;
+        merge_report(
+            &mut combined,
+            report,
+            repository.strip_prefix(workspace).unwrap_or(repository),
+        );
+    }
+    Ok(combined)
+}
+
+fn merge_report(combined: &mut crate::GateReport, mut report: crate::GateReport, prefix: &Path) {
+    combined.status = match (combined.status, report.status) {
+        (GateStatus::Blocked, _) | (_, GateStatus::Blocked) => GateStatus::Blocked,
+        (GateStatus::Warning, _) | (_, GateStatus::Warning) => GateStatus::Warning,
+        _ => GateStatus::Passed,
+    };
+    for finding in &mut report.findings {
+        finding.path = prefix.join(&finding.path);
+    }
+    for check in &mut report.checks {
+        check.name = format!("{}: {}", prefix.display(), check.name);
+    }
+    combined.findings.extend(report.findings);
+    combined.checks.extend(report.checks);
+    combined.summary.errors += report.summary.errors;
+    combined.summary.warnings += report.summary.warnings;
+    combined.summary.info += report.summary.info;
+    combined.summary.blocking_findings += report.summary.blocking_findings;
+    combined.summary.findings_baselined += report.summary.findings_baselined;
+    combined.summary.checks_passed += report.summary.checks_passed;
+    combined.summary.checks_failed += report.summary.checks_failed;
 }
 
 fn compact_failure(report: &crate::GateReport) -> String {

--- a/crates/forgeguard-core/tests/doctor_test.rs
+++ b/crates/forgeguard-core/tests/doctor_test.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, process::Command};
 
 use forgeguard_core::run_doctor;
 use tempfile::tempdir;
@@ -29,4 +29,21 @@ fn current_skill_layout_has_no_migration_warning() {
     let report = run_doctor(directory.path(), None).expect("run doctor");
 
     assert!(report.warnings.is_empty());
+}
+
+#[test]
+fn nested_repository_satisfies_workspace_git_check() {
+    let directory = tempdir().expect("temp directory");
+    let repository = directory.path().join("service");
+    fs::create_dir_all(&repository).expect("create repository");
+    let status = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(&repository)
+        .status()
+        .expect("run git init");
+    assert!(status.success());
+
+    let report = run_doctor(directory.path(), None).expect("run doctor");
+
+    assert!(report.git_repository);
 }

--- a/crates/forgeguard-core/tests/hook_test.rs
+++ b/crates/forgeguard-core/tests/hook_test.rs
@@ -3,8 +3,8 @@ use std::{fs, process::Command};
 use forgeguard_core::{
     evaluate_context_hook, evaluate_scope_hook, evaluate_stop_hook, mark_task_ready,
     mark_task_ready_with_confidence, render_hook_decision, start_task, start_task_with_contract,
-    task_state, update_task_todos, ForgeGuardConfig, GoalContract, HookAgent, HookDecision,
-    TaskStatus,
+    task_state, update_task_todos, CommandConfig, ForgeGuardConfig, GoalContract, GuardMode,
+    HookAgent, HookDecision, TaskStatus,
 };
 use tempfile::tempdir;
 
@@ -562,6 +562,75 @@ fn auto_gate_passes_for_repo_without_code() {
     let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("evaluate hook");
     assert_eq!(decision, HookDecision::Pass);
     assert!(!directory.path().join(".forgeguard").exists());
+}
+
+#[test]
+fn initialized_non_git_workspace_gates_each_nested_repository() {
+    let directory = tempdir().expect("temp directory");
+    let mut workspace_config = ForgeGuardConfig::new("workspace", Vec::new());
+    workspace_config.focus.enabled = false;
+    workspace_config
+        .save(directory.path())
+        .expect("save workspace config");
+
+    let service_a = directory.path().join("service-a");
+    let service_b = directory.path().join("service-b");
+    fs::create_dir_all(&service_a).expect("create service A");
+    fs::create_dir_all(&service_b).expect("create service B");
+    git_init(&service_a);
+    git_init(&service_b);
+    fs::write(service_a.join("service.ts"), "export const ready = true;\n")
+        .expect("write TypeScript service");
+    fs::write(service_b.join("main.rs"), "fn main() {}\n").expect("write Rust service");
+
+    ForgeGuardConfig::new(
+        "service-b",
+        vec![CommandConfig {
+            name: "test".to_owned(),
+            command: "test ! -f main.rs".to_owned(),
+            required: true,
+            enabled: true,
+            timeout_seconds: 10,
+        }],
+    )
+    .save(&service_b)
+    .expect("save service B config");
+
+    let input = format!(r#"{{"cwd":"{}"}}"#, directory.path().display());
+    let (decision, _) =
+        evaluate_stop_hook(directory.path(), &input).expect("evaluate workspace hook");
+
+    assert!(matches!(decision, HookDecision::Block(_)));
+    assert!(!service_a.join(".forgeguard/config.toml").exists());
+    assert!(service_a.join(".forgeguard/reports/latest.json").is_file());
+    assert!(service_b.join(".forgeguard/reports/latest.json").is_file());
+}
+
+#[test]
+fn zero_config_nested_repository_inherits_workspace_config_version() {
+    let directory = tempdir().expect("temp directory");
+    let mut workspace_config = ForgeGuardConfig::new("workspace", Vec::new());
+    workspace_config.version = 1;
+    workspace_config.mode = GuardMode::Strict;
+    workspace_config.focus.enabled = false;
+    workspace_config
+        .save(directory.path())
+        .expect("save workspace config");
+
+    let repository = directory.path().join("service");
+    fs::create_dir_all(&repository).expect("create service");
+    git_init(&repository);
+    fs::write(
+        repository.join("nested.ts"),
+        "for (const row of rows) { for (const value of row) { console.log(value); } }\n",
+    )
+    .expect("write warning-only source");
+
+    let input = format!(r#"{{"cwd":"{}"}}"#, directory.path().display());
+    let (decision, _) =
+        evaluate_stop_hook(directory.path(), &input).expect("evaluate workspace hook");
+
+    assert_eq!(decision, HookDecision::Pass);
 }
 
 fn git_init(root: &std::path::Path) {


### PR DESCRIPTION
## What changed

- discover independent Git repositories below a non-Git initialized workspace
- run Stop-hook gates and language/tool detection per changed repository
- preserve the existing single-repository fast path and workspace config semantics
- report nested Git workspaces correctly in doctor
- bump ForgeGuard to v0.8.1

## Why

Project hooks were installed at the harness workspace root, but Git status was executed there even when the actual repositories lived below it. The hook failed before any nested repository could be checked.

## Verification

- cargo fmt --all -- --check
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace: 97 passed, 0 failed
- cargo deny check
- cargo audit --deny warnings
- installer shell syntax and integration tests
- ForgeGuard gate: 0 errors, 0 warnings, 0 failed checks