### PR TITLE
fix!: activate hooks only in initialized repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]

--- a/crates/forgeguard-cli/Cargo.toml
+++ b/crates/forgeguard-cli/Cargo.toml
@@ -20,4 +20,4 @@ anyhow.workspace = true
 clap.workspace = true
 inquire.workspace = true
 serde_json.workspace = true
-forgeguard-core = { version = "0.8.0", path = "../forgeguard-core" }
+forgeguard-core = { version = "0.9.0", path = "../forgeguard-core" }

--- a/crates/forgeguard-core/src/git.rs
+++ b/crates/forgeguard-core/src/git.rs
@@ -115,7 +115,28 @@ fn status_output(root: &Path) -> Result<Output> {
     Ok(output)
 }
 
+/// Every path reported by `git status` paired with the subset that still exists.
+/// Scanning needs readable files, but a deleted source file still changes build,
+/// lint, and test results, so both views come from one `git status` call.
+pub fn changed_paths_partitioned(
+    root: &Path,
+) -> Result<(Vec<std::path::PathBuf>, Vec<std::path::PathBuf>)> {
+    let all = status_paths(&status_output(root)?.stdout);
+    let existing = all
+        .iter()
+        .filter(|path| root.join(path).is_file())
+        .cloned()
+        .collect();
+    Ok((all, existing))
+}
+
 fn changed_paths(root: &Path, output: &[u8]) -> Result<Vec<std::path::PathBuf>> {
+    let mut paths = status_paths(output);
+    paths.retain(|path| root.join(path).is_file());
+    Ok(paths)
+}
+
+fn status_paths(output: &[u8]) -> Vec<std::path::PathBuf> {
     let mut records = output.split(|byte| *byte == 0).peekable();
     let mut paths = Vec::new();
     while let Some(record) = records.next() {
@@ -123,11 +144,7 @@ fn changed_paths(root: &Path, output: &[u8]) -> Result<Vec<std::path::PathBuf>> 
             continue;
         }
         let status = &record[..2];
-        let raw_path = &record[3..];
-        let path = path_from_git_bytes(raw_path);
-        if root.join(&path).is_file() {
-            paths.push(path);
-        }
+        paths.push(path_from_git_bytes(&record[3..]));
 
         if status.iter().any(|value| matches!(*value, b'R' | b'C')) {
             let _ = records.next();
@@ -136,7 +153,7 @@ fn changed_paths(root: &Path, output: &[u8]) -> Result<Vec<std::path::PathBuf>> 
 
     paths.sort();
     paths.dedup();
-    Ok(paths)
+    paths
 }
 
 fn path_from_git_bytes(value: &[u8]) -> std::path::PathBuf {

--- a/crates/forgeguard-core/src/hook.rs
+++ b/crates/forgeguard-core/src/hook.rs
@@ -3,6 +3,7 @@ use std::{
     fs,
     hash::Hasher,
     path::{Component, Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{bail, Context, Result};
@@ -12,13 +13,26 @@ use serde_json::{json, Value};
 use crate::{
     config::{FocusConfig, ForgeGuardConfig, GuardMode, CONFIG_FILE},
     detect_project,
-    git::{changed_files, repository_roots, worktree_fingerprint},
+    git::{changed_paths_partitioned, repository_roots, worktree_fingerprint},
     model::GateSummary,
     report::{render_gate_compact, COMPACT_MAX_CHARS},
     run_gate, GateOptions, GateStatus,
 };
 
 const CACHE_DIR: &str = ".forgeguard/cache/stop";
+/// A second hook registration for the same event (for example a global and a
+/// project `settings.json` both installing the stop hook) fires within
+/// milliseconds. Replaying the first decision inside this window keeps retry,
+/// no-progress, and auto-poke budgets tied to agent turns instead of to the
+/// number of installed hook entries.
+const DUPLICATE_STOP_WINDOW_MILLIS: u64 = 1_500;
+/// Extensions that cannot change build, lint, or test results, so a stop-hook
+/// gate over only these paths runs the scanner without the configured
+/// commands.
+const DOCUMENTATION_EXTENSIONS: [&str; 17] = [
+    "md", "mdx", "markdown", "rst", "adoc", "asciidoc", "org", "txt", "text", "png", "jpg", "jpeg",
+    "gif", "webp", "svg", "ico", "pdf",
+];
 const TASK_DIR: &str = ".forgeguard/cache/tasks";
 const REPORT_FILE: &str = ".forgeguard/reports/latest.json";
 const MAX_OBJECTIVE_CHARS: usize = 4_000;
@@ -50,6 +64,14 @@ pub enum HookDecision {
     Pass,
     Block(String),
     Stop(String),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct HookReplay {
+    state: String,
+    at_millis: u64,
+    stop: bool,
+    message: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -128,13 +150,44 @@ pub fn evaluate_stop_hook(fallback_root: &Path, input: &str) -> Result<(HookDeci
     let Some(root) = find_project_root(fallback_root, &payload) else {
         return Ok((HookDecision::Pass, false));
     };
+    if !is_hook_project(&root)? {
+        return Ok((HookDecision::Pass, false));
+    }
     let repositories = repository_roots(&root)?;
     if repositories.is_empty() {
         return Ok((HookDecision::Pass, false));
     }
     let session = session_key(&payload);
-    let mut task = read_task(&root, &session)?;
     let worktree = workspace_fingerprint(&root, &repositories)?;
+    let worktree_key = worktree.as_deref().unwrap_or("clean").to_owned();
+    if let Some(decision) = replayed_decision(
+        &root,
+        &session,
+        &stop_state_key(&root, &session, &worktree_key)?,
+    ) {
+        return Ok((decision, true));
+    }
+    let evaluated = evaluate_stop_state(&root, &session, &repositories, worktree)?;
+    // The decision may have advanced the task, so the replay key describes the
+    // state a duplicate hook registration observes, not the state this call saw.
+    record_replay(
+        &root,
+        &session,
+        &stop_state_key(&root, &session, &worktree_key)?,
+        &evaluated.0,
+    )?;
+    Ok(evaluated)
+}
+
+fn evaluate_stop_state(
+    root: &Path,
+    session: &str,
+    repositories: &[PathBuf],
+    worktree: Option<String>,
+) -> Result<(HookDecision, bool)> {
+    let root = root.to_path_buf();
+    let session = session.to_owned();
+    let mut task = read_task(&root, &session)?;
     if worktree.is_none() {
         match task.as_ref().map(|task| task.status) {
             None | Some(TaskStatus::Completed | TaskStatus::Blocked) => {
@@ -206,7 +259,7 @@ pub fn evaluate_stop_hook(fallback_root: &Path, input: &str) -> Result<(HookDeci
             false,
         );
     }
-    let report = run_workspace_gate(&root, &repositories, &config)?;
+    let report = run_workspace_gate(&root, repositories, &config)?;
     write_json(&root.join(REPORT_FILE), &report)?;
     if report.status == GateStatus::Blocked {
         return bounded_block(
@@ -350,9 +403,16 @@ pub fn start_task_with_contract(
         .into_iter()
         .map(|text| TaskTodo { text, done: false })
         .collect();
+    // Carrying the auto-poke budget over stops an agent from escaping it by
+    // reframing the same work. A blocked task is different: the session already
+    // reported its blocker and stopped, so the next objective starts fresh
+    // instead of being stopped before its first turn.
     let previous = read_task(root, session_id)?;
     let (auto_pokes, confidence_history) = previous
-        .filter(|task| task.status != TaskStatus::Completed)
+        .filter(|task| {
+            task.status != TaskStatus::Completed
+                && !(task.status == TaskStatus::Blocked && task.objective != objective)
+        })
         .map_or((0, Vec::new()), |task| {
             (task.auto_pokes, task.confidence_history)
         });
@@ -635,11 +695,12 @@ fn find_project_root(fallback_root: &Path, payload: &Value) -> Option<PathBuf> {
     })
 }
 
+/// Hooks are opt-in: only a repository or workspace initialized with
+/// `forgeguard init` is guarded. Detecting a language is not consent, and
+/// silently gating a repository the user never initialized turns unrelated
+/// work (documentation, research, MCP) into blocked agent turns.
 fn is_hook_project(root: &Path) -> Result<bool> {
-    if root.join(CONFIG_FILE).is_file() {
-        return Ok(true);
-    }
-    Ok(!detect_project(root)?.languages.is_empty())
+    Ok(root.join(CONFIG_FILE).is_file())
 }
 
 fn workspace_fingerprint(workspace: &Path, repositories: &[PathBuf]) -> Result<Option<String>> {
@@ -672,12 +733,13 @@ fn run_workspace_gate(
     workspace_config: &ForgeGuardConfig,
 ) -> Result<crate::GateReport> {
     if repositories == [workspace] {
+        let (changed, existing) = changed_paths_partitioned(workspace)?;
         return run_gate(
             workspace,
             workspace_config,
             &GateOptions {
-                skip_commands: false,
-                paths: Some(changed_files(workspace)?),
+                skip_commands: !changes_require_commands(&changed),
+                paths: Some(existing),
             },
         );
     }
@@ -711,12 +773,13 @@ fn run_workspace_gate(
             config.policies = workspace_config.policies.clone();
             config.rules = workspace_config.rules.clone();
         }
+        let (changed, existing) = changed_paths_partitioned(repository)?;
         let report = run_gate(
             repository,
             &config,
             &GateOptions {
-                skip_commands: false,
-                paths: Some(changed_files(repository)?),
+                skip_commands: !changes_require_commands(&changed),
+                paths: Some(existing),
             },
         )?;
         write_json(&repository.join(REPORT_FILE), &report)?;
@@ -727,6 +790,39 @@ fn run_workspace_gate(
         );
     }
     Ok(combined)
+}
+
+/// Build, lint, and test commands only observe code and manifests. When every
+/// changed path is documentation or an asset, running them costs minutes and
+/// can block a stop on a failure the change did not cause. Anything not
+/// recognized as documentation still runs the commands.
+fn changes_require_commands(paths: &[PathBuf]) -> bool {
+    if paths.is_empty() {
+        return true;
+    }
+    !paths.iter().all(|path| is_documentation_path(path))
+}
+
+fn is_documentation_path(path: &Path) -> bool {
+    // A Markdown or text file under a test tree is a fixture: the commands read
+    // it, so a change to it must still run them.
+    if path.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|name| {
+            matches!(
+                name.to_ascii_lowercase().as_str(),
+                "test" | "tests" | "__tests__" | "spec" | "specs" | "fixtures" | "testdata"
+            )
+        })
+    }) {
+        return false;
+    }
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            DOCUMENTATION_EXTENSIONS
+                .iter()
+                .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+        })
 }
 
 fn merge_report(combined: &mut crate::GateReport, mut report: crate::GateReport, prefix: &Path) {
@@ -791,14 +887,12 @@ fn bounded_block(
     focus: &FocusConfig,
     cache_hit: bool,
 ) -> Result<(HookDecision, bool)> {
-    let attempts = previous.map_or(1, |cache| cache.attempts.saturating_add(1));
-    let stalled_attempts = previous.map_or(0, |cache| {
-        if cache.fingerprint == fingerprint {
-            cache.stalled_attempts.saturating_add(1)
-        } else {
-            0
-        }
-    });
+    // Both budgets measure the same thing: attempts against unchanged state.
+    // Counting attempts across changed fingerprints would stop a session that
+    // makes real progress on every turn.
+    let repeated = previous.filter(|cache| cache.fingerprint == fingerprint);
+    let attempts = repeated.map_or(1, |cache| cache.attempts.saturating_add(1));
+    let stalled_attempts = repeated.map_or(0, |cache| cache.stalled_attempts.saturating_add(1));
     let max_retries = focus.max_retries.max(1);
     let no_progress_limit = focus.no_progress_limit.max(1);
     let exhausted = attempts > max_retries || stalled_attempts >= no_progress_limit;
@@ -1225,6 +1319,57 @@ fn read_task(root: &Path, session: &str) -> Result<Option<TaskState>> {
 
 fn write_task(root: &Path, task: &TaskState) -> Result<()> {
     write_json(&task_path(root, &task.session_id), task)
+}
+
+fn replay_path(root: &Path, session: &str) -> PathBuf {
+    root.join(CACHE_DIR).join(format!("{session}.replay.json"))
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+fn stop_state_key(root: &Path, session: &str, worktree: &str) -> Result<String> {
+    Ok(format!(
+        "{worktree}:{}",
+        task_signature(read_task(root, session)?.as_ref())
+    ))
+}
+
+fn replayed_decision(root: &Path, session: &str, state: &str) -> Option<HookDecision> {
+    let source = fs::read_to_string(replay_path(root, session)).ok()?;
+    let replay: HookReplay = serde_json::from_str(&source).ok()?;
+    if replay.state != state {
+        return None;
+    }
+    if now_millis().saturating_sub(replay.at_millis) >= DUPLICATE_STOP_WINDOW_MILLIS {
+        return None;
+    }
+    Some(if replay.stop {
+        HookDecision::Stop(replay.message)
+    } else {
+        HookDecision::Block(replay.message)
+    })
+}
+
+fn record_replay(root: &Path, session: &str, state: &str, decision: &HookDecision) -> Result<()> {
+    let (stop, message) = match decision {
+        HookDecision::Pass => return Ok(()),
+        HookDecision::Block(message) => (false, message.clone()),
+        HookDecision::Stop(message) => (true, message.clone()),
+    };
+    write_json(
+        &replay_path(root, session),
+        &HookReplay {
+            state: state.to_owned(),
+            at_millis: now_millis(),
+            stop,
+            message,
+        },
+    )
 }
 
 fn cache_path(root: &Path, session: &str) -> PathBuf {

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -13,6 +13,17 @@ const AGENTS_TEMPLATE: &str = include_str!("../assets/templates/AGENTS.md");
 const CLAUDE_TEMPLATE: &str = include_str!("../assets/templates/CLAUDE.md");
 const CURSOR_TEMPLATE: &str = include_str!("../assets/templates/CURSOR.md");
 const FORGEGUARD_GITIGNORE: &str = "cache/\nreports/\n";
+const AGENT_HOOK_FILES: [&str; 5] = [
+    ".claude/settings.json",
+    ".codex/hooks.json",
+    ".cursor/hooks.json",
+    ".agents/hooks.json",
+    ".gemini/config/hooks.json",
+];
+const DEFAULT_STOP_HOOK_TIMEOUT_SECONDS: u64 = 600;
+const MAX_STOP_HOOK_TIMEOUT_SECONDS: u64 = 3_600;
+/// Scan and report time on top of the configured command budget.
+const STOP_HOOK_TIMEOUT_MARGIN_SECONDS: u64 = 120;
 pub(crate) const CODEX_HOOK_COMMAND: &str = "forgeguard hook stop --agent codex";
 pub(crate) const CLAUDE_HOOK_COMMAND: &str = "forgeguard hook stop --agent claude";
 pub(crate) const CURSOR_HOOK_COMMAND: &str = "forgeguard hook stop --agent cursor";
@@ -189,6 +200,7 @@ pub fn initialize_project(root: &Path, options: &InitOptions) -> Result<InitRepo
         &mut files_written,
         &mut files_skipped,
     )?;
+    refresh_stop_hook_timeouts(root, &mut files_written)?;
     ignore_project_agent_directories(root, &options.agents, &mut files_written)?;
 
     Ok(InitReport {
@@ -572,6 +584,72 @@ fn remove_obsolete_skill_assets(root: &Path, directory: &str) -> Result<()> {
     Ok(())
 }
 
+/// The stop hook runs the configured commands, so the host must wait at least
+/// as long as those commands may take. A host timeout shorter than the command
+/// budget kills the gate mid-run: the decision is lost and the next stop repeats
+/// the whole suite.
+fn stop_hook_timeout_seconds(root: &Path) -> u64 {
+    let Ok(config) = ForgeGuardConfig::load(root) else {
+        return DEFAULT_STOP_HOOK_TIMEOUT_SECONDS;
+    };
+    let budget = config
+        .commands
+        .iter()
+        .filter(|command| command.enabled)
+        .fold(0_u64, |total, command| {
+            total.saturating_add(command.timeout_seconds)
+        })
+        .saturating_add(STOP_HOOK_TIMEOUT_MARGIN_SECONDS);
+    budget.clamp(
+        DEFAULT_STOP_HOOK_TIMEOUT_SECONDS,
+        MAX_STOP_HOOK_TIMEOUT_SECONDS,
+    )
+}
+
+/// Hook entries installed by an earlier version keep their original timeout,
+/// because every installer skips a command it already finds. A repository whose
+/// command budget grew past that timeout would have its gate killed mid-run, so
+/// initialization repairs existing stop-hook entries too.
+fn refresh_stop_hook_timeouts(root: &Path, written: &mut Vec<String>) -> Result<()> {
+    let timeout = stop_hook_timeout_seconds(root);
+    for relative in AGENT_HOOK_FILES {
+        let path = root.join(relative);
+        if !path.is_file() {
+            continue;
+        }
+        let mut document = read_json_object(&path)?;
+        if !set_stop_hook_timeout(&mut document, timeout) {
+            continue;
+        }
+        write_json_document(root, &path, &document, written)?;
+    }
+    Ok(())
+}
+
+fn set_stop_hook_timeout(value: &mut Value, timeout: u64) -> bool {
+    match value {
+        Value::Object(fields) => {
+            let is_stop_hook = fields
+                .get("command")
+                .and_then(Value::as_str)
+                .is_some_and(|command| command.contains("forgeguard hook stop"));
+            let mut changed = false;
+            if is_stop_hook && fields.get("timeout") != Some(&json!(timeout)) {
+                fields.insert("timeout".to_owned(), json!(timeout));
+                changed = true;
+            }
+            for nested in fields.values_mut() {
+                changed |= set_stop_hook_timeout(nested, timeout);
+            }
+            changed
+        }
+        Value::Array(values) => values.iter_mut().fold(false, |changed, nested| {
+            changed | set_stop_hook_timeout(nested, timeout)
+        }),
+        _ => false,
+    }
+}
+
 fn install_grouped_hook(
     root: &Path,
     path: &Path,
@@ -590,7 +668,7 @@ fn install_grouped_hook(
     let command_hook = json!({
         "type": "command",
         "command": command,
-        "timeout": if event == "Stop" { 600 } else { 5 }
+        "timeout": if event == "Stop" { stop_hook_timeout_seconds(root) } else { 5 }
     });
     let mut handler = json!({"hooks": [command_hook]});
     if let Some(matcher) = matcher {
@@ -622,7 +700,7 @@ fn install_cursor_hook(
     let hooks = object_field(&mut document, "hooks", path)?;
     let mut handler = json!({
         "command": command,
-        "timeout": if event == "stop" { 600 } else { 5 }
+        "timeout": if event == "stop" { stop_hook_timeout_seconds(root) } else { 5 }
     });
     if let Some(matcher) = matcher {
         handler["matcher"] = json!(matcher);
@@ -657,7 +735,7 @@ fn install_antigravity_simple_hook(
     array_field(hook, event, path)?.push(json!({
         "type": "command",
         "command": command,
-        "timeout": if event == "Stop" { 600 } else { 5 }
+        "timeout": if event == "Stop" { stop_hook_timeout_seconds(root) } else { 5 }
     }));
     write_json_document(root, path, &document, written)
 }

--- a/crates/forgeguard-core/tests/hook_test.rs
+++ b/crates/forgeguard-core/tests/hook_test.rs
@@ -51,11 +51,17 @@ fn blocked_hook_is_compact_cached_and_bounded() {
         r#"{{"cwd":"{}","stop_hook_active":true}}"#,
         directory.path().display()
     );
+    // Later agent turns, not duplicate hook entries: step past the replay window.
+    sleep_past_duplicate_window();
     let (decision, cache_hit) =
         evaluate_stop_hook(directory.path(), &repeated).expect("evaluate repeated hook");
-    assert!(matches!(decision, HookDecision::Stop(_)));
+    let HookDecision::Block(message) = decision else {
+        panic!("the second unchanged turn is still inside the retry budget");
+    };
+    assert!(message.contains("no-progress 1/2"));
     assert!(cache_hit);
 
+    sleep_past_duplicate_window();
     let antigravity_repeated = format!(
         r#"{{"workspacePaths":["{}"],"executionNum":2}}"#,
         directory.path().display()
@@ -565,40 +571,297 @@ fn task_contract_rejects_untrusted_paths_and_unsupported_evidence() {
 }
 
 #[test]
-fn auto_gate_reports_without_blocking_without_config_and_ignores_artifacts() {
+fn uninitialized_code_repository_is_never_hooked_or_written_to() {
     let directory = tempdir().expect("temp directory");
     git_init(directory.path());
-    // A pre-existing root .gitignore must be appended to, not clobbered.
     fs::write(directory.path().join(".gitignore"), "node_modules/\n").expect("write gitignore");
     fs::write(
         directory.path().join("service.ts"),
         "import { PrismaClient } from '@prisma/client';\nconst db = new PrismaClient();\nfor (const user of users) { await db.query('SELECT id FROM users WHERE id = 1'); }\n",
     )
     .expect("write source");
+    start_task(
+        directory.path(),
+        "session-uninitialized",
+        "Write documentation only",
+        &["docs".to_owned()],
+        false,
+    )
+    .expect("write stale task");
 
     let input = format!(
-        r#"{{"cwd":"{}","executionNum":1}}"#,
+        r#"{{"cwd":"{}","session_id":"session-uninitialized","executionNum":1,"tool_input":{{"file_path":"service.ts"}}}}"#,
         directory.path().display()
     );
     assert!(
         evaluate_context_hook(directory.path(), &input, HookAgent::Codex)
             .expect("evaluate context hook")
-            .is_some()
+            .is_none()
     );
+    assert!(evaluate_scope_hook(directory.path(), &input)
+        .expect("evaluate scope hook")
+        .is_none());
     let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("evaluate hook");
     assert_eq!(decision, HookDecision::Pass);
 
-    // No manual setup, yet artifacts are kept out of version control.
-    let marker = fs::read_to_string(directory.path().join(".forgeguard/.gitignore"))
-        .expect("read forgeguard gitignore");
-    assert_eq!(marker.trim(), "*");
+    // Without `forgeguard init` the hooks own nothing in the repository.
+    assert!(!directory.path().join(".forgeguard/config.toml").exists());
+    assert!(!directory.path().join(".forgeguard/.gitignore").exists());
+    assert!(!directory
+        .path()
+        .join(".forgeguard/reports/latest.json")
+        .exists());
     let root_ignore =
         fs::read_to_string(directory.path().join(".gitignore")).expect("read root gitignore");
-    assert!(root_ignore.contains("node_modules/"));
-    assert!(root_ignore
-        .lines()
-        .any(|line| line.trim().trim_end_matches('/') == ".forgeguard"));
-    assert!(!directory.path().join(".forgeguard/config.toml").exists());
+    assert_eq!(root_ignore, "node_modules/\n");
+}
+
+#[test]
+fn initialized_repository_activates_every_hook() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = GuardMode::Strict;
+    config.focus.auto_poke = false;
+    config.save(directory.path()).expect("save config");
+    fs::write(
+        directory.path().join("service.ts"),
+        "import { PrismaClient } from '@prisma/client';\nconst db = new PrismaClient();\nfor (const user of users) { await db.query('SELECT id FROM users WHERE id = 1'); }\n",
+    )
+    .expect("write source");
+    start_task(
+        directory.path(),
+        "session-initialized",
+        "Change only source",
+        &["src".to_owned()],
+        false,
+    )
+    .expect("start task");
+
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"session-initialized","tool_input":{{"file_path":"service.ts"}}}}"#,
+        directory.path().display()
+    );
+    assert!(
+        evaluate_context_hook(directory.path(), &input, HookAgent::Codex)
+            .expect("evaluate context hook")
+            .expect("context")
+            .contains("Change only source")
+    );
+    assert!(evaluate_scope_hook(directory.path(), &input)
+        .expect("evaluate scope hook")
+        .expect("scope warning")
+        .contains("service.ts"));
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("evaluate hook");
+    assert!(matches!(decision, HookDecision::Block(_)));
+    assert!(directory
+        .path()
+        .join(".forgeguard/reports/latest.json")
+        .is_file());
+}
+
+#[test]
+fn documentation_only_change_skips_configured_commands() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let failing = CommandConfig {
+        name: "test".to_owned(),
+        command: "exit 1".to_owned(),
+        required: true,
+        enabled: true,
+        timeout_seconds: 10,
+    };
+    let mut config = ForgeGuardConfig::new("sample", vec![failing]);
+    config.focus.enabled = false;
+    config.save(directory.path()).expect("save config");
+    fs::write(
+        directory.path().join("service.ts"),
+        "export const value = 1;\n",
+    )
+    .expect("write source");
+    git_commit_all(directory.path());
+    fs::write(directory.path().join("guide.md"), "# guide\n").expect("write documentation");
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"session-docs"}}"#,
+        directory.path().display()
+    );
+
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("documentation stop");
+    assert_eq!(decision, HookDecision::Pass);
+
+    // A removed source file changes build, lint, and test results even though
+    // the path no longer exists on disk.
+    fs::remove_file(directory.path().join("service.ts")).expect("remove source");
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("removal stop");
+    let HookDecision::Block(message) = decision else {
+        panic!("a removed source file must run the configured commands");
+    };
+    assert!(message.contains("test failed"));
+
+    fs::write(
+        directory.path().join("service.ts"),
+        "export const value = 2;\n",
+    )
+    .expect("rewrite source");
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("source stop");
+    let HookDecision::Block(message) = decision else {
+        panic!("a source change must run the configured commands");
+    };
+    assert!(message.contains("test failed"));
+}
+
+#[test]
+fn markdown_under_a_test_tree_is_a_fixture_and_still_runs_commands() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let failing = CommandConfig {
+        name: "test".to_owned(),
+        command: "exit 1".to_owned(),
+        required: true,
+        enabled: true,
+        timeout_seconds: 10,
+    };
+    let mut config = ForgeGuardConfig::new("sample", vec![failing]);
+    config.focus.enabled = false;
+    config.save(directory.path()).expect("save config");
+    fs::create_dir_all(directory.path().join("tests/fixtures")).expect("create fixtures");
+    fs::write(
+        directory.path().join("tests/fixtures/expected.md"),
+        "# expected\n",
+    )
+    .expect("write fixture");
+    git_commit_all(directory.path());
+    fs::write(
+        directory.path().join("tests/fixtures/expected.md"),
+        "# expected output\n",
+    )
+    .expect("edit fixture");
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"session-fixture"}}"#,
+        directory.path().display()
+    );
+
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("fixture stop");
+    let HookDecision::Block(message) = decision else {
+        panic!("a fixture change must run the configured commands");
+    };
+    assert!(message.contains("test failed"));
+}
+
+#[test]
+fn duplicate_hook_registration_does_not_consume_the_retry_budget() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = GuardMode::Strict;
+    config.focus.auto_poke = false;
+    config.save(directory.path()).expect("save config");
+    fs::write(
+        directory.path().join("service.ts"),
+        "export const value = 1;\n",
+    )
+    .expect("write source");
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"session-duplicate"}}"#,
+        directory.path().display()
+    );
+
+    // A global and a project hook entry fire the same event back to back.
+    let (first, _) = evaluate_stop_hook(directory.path(), &input).expect("first registration");
+    let (second, cache_hit) =
+        evaluate_stop_hook(directory.path(), &input).expect("duplicate registration");
+    assert_eq!(first, second);
+    assert!(cache_hit);
+    assert!(matches!(second, HookDecision::Block(message) if message.contains("attempt 1/3")));
+}
+
+#[test]
+fn retry_budget_resets_when_the_worktree_advances() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.mode = GuardMode::Strict;
+    config.focus.auto_poke = false;
+    config.save(directory.path()).expect("save config");
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"session-progress"}}"#,
+        directory.path().display()
+    );
+
+    for index in 0..5 {
+        fs::write(
+            directory.path().join(format!("service-{index}.ts")),
+            "export const value = 1;\n",
+        )
+        .expect("write source");
+        start_task(
+            directory.path(),
+            "session-progress",
+            &format!("Ship increment {index}"),
+            &[],
+            false,
+        )
+        .expect("start task");
+        let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("progress stop");
+        let HookDecision::Block(message) = decision else {
+            panic!("a session that advances every turn must not be stopped");
+        };
+        assert!(message.contains("attempt 1/3"));
+        assert!(message.contains("no-progress 0/2"));
+    }
+}
+
+#[test]
+fn a_new_objective_after_a_blocked_task_starts_with_a_fresh_poke_budget() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    let mut config = ForgeGuardConfig::new("sample", Vec::new());
+    config.focus.auto_poke = true;
+    config.focus.max_auto_pokes = 1;
+    config.save(directory.path()).expect("save config");
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"session-recover"}}"#,
+        directory.path().display()
+    );
+
+    start_task(
+        directory.path(),
+        "session-recover",
+        "Improve latency",
+        &[],
+        false,
+    )
+    .expect("start abstract task");
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("first poke");
+    assert!(matches!(decision, HookDecision::Block(_)));
+    fs::write(
+        directory.path().join("service.ts"),
+        "export const value = 1;\n",
+    )
+    .expect("write source");
+    let (decision, _) = evaluate_stop_hook(directory.path(), &input).expect("exhausted poke");
+    assert!(matches!(decision, HookDecision::Stop(_)));
+    assert_eq!(
+        task_state(directory.path(), "session-recover")
+            .expect("read task")
+            .expect("task")
+            .status,
+        TaskStatus::Blocked
+    );
+
+    start_task(
+        directory.path(),
+        "session-recover",
+        "Document the release process",
+        &[],
+        false,
+    )
+    .expect("start new objective");
+    let task = task_state(directory.path(), "session-recover")
+        .expect("read task")
+        .expect("task");
+    assert_eq!(task.auto_pokes, 0);
+    assert_eq!(task.status, TaskStatus::Active);
 }
 
 #[test]
@@ -721,6 +984,32 @@ fn zero_config_nested_repository_inherits_workspace_config_version() {
         evaluate_stop_hook(directory.path(), &input).expect("evaluate workspace hook");
 
     assert_eq!(decision, HookDecision::Pass);
+}
+
+fn git_commit_all(root: &std::path::Path) {
+    for arguments in [
+        vec!["add", "-A"],
+        vec![
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=test",
+            "commit",
+            "-qm",
+            "init",
+        ],
+    ] {
+        let status = Command::new("git")
+            .args(arguments)
+            .current_dir(root)
+            .status()
+            .expect("run git");
+        assert!(status.success());
+    }
+}
+
+fn sleep_past_duplicate_window() {
+    std::thread::sleep(std::time::Duration::from_millis(1_600));
 }
 
 fn git_init(root: &std::path::Path) {

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use forgeguard_core::{initialize_project, AgentTarget, InitOptions};
+use forgeguard_core::{initialize_project, AgentTarget, ForgeGuardConfig, InitOptions};
 use tempfile::tempdir;
 
 #[test]
@@ -181,6 +181,98 @@ fn installs_global_skills_without_project_configuration() {
     assert!(directory.path().join(".gemini/config/hooks.json").exists());
     assert!(!directory.path().join(".forgeguard/config.toml").exists());
     assert!(!report.files_written.is_empty());
+}
+
+#[test]
+fn stop_hook_timeout_covers_the_configured_command_budget() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("Cargo.toml"),
+        "[package]\nname = \"sample\"\n",
+    )
+    .expect("write manifest");
+
+    initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: false,
+            agents: vec![AgentTarget::Claude],
+        },
+    )
+    .expect("initialize project");
+
+    let config = ForgeGuardConfig::load(directory.path()).expect("load config");
+    let budget: u64 = config
+        .commands
+        .iter()
+        .filter(|command| command.enabled)
+        .map(|command| command.timeout_seconds)
+        .sum();
+    assert!(
+        budget > 600,
+        "the Rust preset must exceed one command budget"
+    );
+    let settings: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(directory.path().join(".claude/settings.json")).expect("read settings"),
+    )
+    .expect("parse settings");
+    let timeout = settings["hooks"]["Stop"][0]["hooks"][0]["timeout"]
+        .as_u64()
+        .expect("stop hook timeout");
+    assert!(
+        timeout >= budget,
+        "stop hook timeout {timeout} must cover the {budget}s command budget"
+    );
+}
+
+#[test]
+fn reinitialization_repairs_a_stop_hook_timeout_below_the_command_budget() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("Cargo.toml"),
+        "[package]\nname = \"sample\"\n",
+    )
+    .expect("write manifest");
+    let settings = directory.path().join(".claude/settings.json");
+    fs::create_dir_all(settings.parent().expect("settings parent")).expect("create settings");
+    // An entry written by an earlier version: correct command, stale timeout.
+    fs::write(
+        &settings,
+        r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"forgeguard hook stop --agent claude","timeout":600}]}]}}"#,
+    )
+    .expect("write legacy settings");
+
+    initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: false,
+            agents: vec![AgentTarget::Claude],
+        },
+    )
+    .expect("initialize project");
+
+    let config = ForgeGuardConfig::load(directory.path()).expect("load config");
+    let budget: u64 = config
+        .commands
+        .iter()
+        .filter(|command| command.enabled)
+        .map(|command| command.timeout_seconds)
+        .sum();
+    let value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&settings).expect("read settings"))
+            .expect("parse settings");
+    let timeout = value["hooks"]["Stop"][0]["hooks"][0]["timeout"]
+        .as_u64()
+        .expect("stop hook timeout");
+    assert!(
+        timeout >= budget,
+        "existing stop hook timeout {timeout} must be repaired to cover {budget}s"
+    );
+    assert_eq!(
+        value.to_string().matches("forgeguard hook stop").count(),
+        1,
+        "repair must not duplicate the hook entry"
+    );
 }
 
 #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,10 @@ Source walking honors Git ignore files and excludes generated or dependency dire
 ## Hook policy
 
 - Hooks merge into existing JSON without replacing unrelated settings.
-- Global hooks pass silently outside initialized repositories.
+- Global hooks pass silently outside initialized repositories. Activation requires `.forgeguard/config.toml`; a detected language is never treated as consent. Nested repositories inside an initialized workspace inherit that activation.
+- A repeated stop decision for unchanged repository and task state is replayed for a short window, so a duplicated hook registration cannot consume the retry, no-progress, or auto-poke budget.
+- Stop-hook gates skip the configured commands when every changed path is documentation or an asset; the scanner still runs.
+- `forgeguard init` writes a stop-hook timeout that covers the configured command budget.
 - Claude and Codex return `decision: block`; Cursor returns `followup_message`; Antigravity returns `decision: continue`.
 - Session start/resume/compaction hooks restore the active objective where the host protocol supports context injection; Antigravity injects it on the first model invocation of an execution.
 - Pre-tool hooks warn when an edit path falls outside explicitly declared repository-relative prefixes. ForgeGuard never infers scope from prompt text.

--- a/docs/FOCUS.md
+++ b/docs/FOCUS.md
@@ -2,6 +2,8 @@
 
 ForgeGuard installs focus enforcement with `forgeguard init`. No extra configuration is required for new repositories. Auto-poke is enabled by default and remains bounded.
 
+Enforcement is opt-in: every hook passes silently until `.forgeguard/config.toml` exists in the repository or workspace root, so a repository you never initialized is never gated, never blocked, and never written to.
+
 ## Lifecycle hooks
 
 ForgeGuard uses three hooks where the host supports them:
@@ -41,6 +43,8 @@ model ends turn
 ```
 
 Every continuation is a new host request. Generated configuration allows three auto-pokes. ForgeGuard clamps any configured value to a hard maximum of five. Retry and no-progress budgets separately bound unchanged failures.
+
+Both budgets count attempts against unchanged repository and task state only; a turn that advances either one starts a fresh budget. A blocked task keeps its auto-poke budget while the objective stays the same, and releases it when the session registers a different objective, so a stopped session can start new work instead of being stopped before its first turn.
 
 ## Hill-climbability contract
 


### PR DESCRIPTION
Hooks fired in any repository with a detected language, so a repository that never ran `forgeguard init` was gated, blocked, and written to. That contradicted `docs/ARCHITECTURE.md`, which states global hooks pass silently outside initialized repositories.

## Changes

- **Init-only activation.** `is_hook_project` now requires `.forgeguard/config.toml`; a detected language is no longer treated as consent. `evaluate_stop_hook` uses the guard too — it previously had none. Nested repositories inside an initialized workspace still inherit gating.
- **Retry budget.** Retry and no-progress counters both reset when the worktree or task state advances. A session that progressed on every turn could previously exhaust the budget and receive `continue: false`.
- **Duplicate hook registrations.** A stop decision is replayed for 1.5s when repository and task state are unchanged, so a global and a project hook entry firing the same event consume one turn of budget, not two.
- **Auto-poke recovery.** A blocked task releases its auto-poke budget when the session registers a different objective. Reframing the same objective still carries the budget over.
- **Command scope.** Gates skip the configured commands when every changed path is documentation or an asset. Removed paths and files under `test/`, `tests/`, `spec/`, `fixtures/`, `testdata/` still run them.
- **Timeouts.** `forgeguard init` writes a stop-hook timeout covering the configured command budget and repairs existing entries whose timeout is too short.

## Verification

```
cargo test --locked --workspace              107 passed, 0 failed
cargo clippy ... -D warnings                 no issues
cargo fmt --all -- --check                   clean
forgeguard gate --output compact             0 errors, 0 warnings, 0 failed checks
forgeguard doctor                            healthy
```

Manual reproduction in a scratch repository:

| scenario | result |
|---|---|
| uninitialized repo, stop and context hooks | no output, no `.forgeguard/`, `.gitignore` untouched |
| after `forgeguard init`, source change | `decision: block` |
| after `forgeguard init`, markdown-only change | pass |
| deleted source file plus markdown edit | `decision: block` |
| two hook registrations, same event | identical decision, one attempt consumed |
| five turns with real progress | `attempt 1/3` each turn, no stop |
| four turns without progress | escalates to stop on turn three |
| stop timeout vs command budget | 720s >= 600s |

## Breaking change

Repositories without `.forgeguard/config.toml` are no longer gated. Run `forgeguard init` to keep enforcement.