### PR TITLE
feat: add cross-agent clarification guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "forgeguard-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 authors = ["SuiFlex"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ForgeGuard is designed not to drain user context or model limits:
 
 - The hook runs a local Rust binary and repository commands; ForgeGuard itself makes no LLM or external API call.
 - Always-on policy stays compact; detailed backend, frontend, mobile, database, algorithm, testing, and AI references load only when relevant.
-- Passing completion hooks add no model context in Codex/Claude; objective reinjection caps objective text at 300 characters, and scope feedback appears only for an explicit out-of-scope path.
+- Passing completion hooks add no model context in Codex/Claude; supported lifecycle hooks inject one compact material-ambiguity reminder, Claude refreshes it per user prompt, and OpenCode receives the same rule through the shared skill.
 - Antigravity injects focus context only on the first model invocation of an execution.
 - Blocking feedback is deduplicated and capped at 2,000 characters and five findings.
 - Auto-poke is default-on and creates one host request per continuation; the generated limit is three and the hard cap is five.
@@ -64,6 +64,7 @@ A blocked gate may cause the host agent to use another turn to fix real failures
 - OpenCode `AGENTS.md` plus shared project skills.
 - Antigravity rule, shared project skill, and native `Stop` hook.
 - Token-efficient `Stop` hooks: silent pass, bounded failure feedback, diff cache, and local full report.
+- Cross-agent material-ambiguity guard: native context hooks for Claude, Codex, Cursor, and Antigravity; shared skill fallback for OpenCode.
 - Session-scoped objective, todo, confidence, hill-climbability, auto-poke, resume, and scope-drift state.
 - One `forgeguard-engineering` skill with conditional clean-code, algorithm, backend, frontend, mobile, database, AI, and testing references.
 - Static rules for nested iteration, repeated linear lookup, sorting in loops, database I/O in loops, external requests in loops, unbounded fan-out, `SELECT *`, and potential duplicated blocks.

--- a/crates/forgeguard-cli/Cargo.toml
+++ b/crates/forgeguard-cli/Cargo.toml
@@ -20,4 +20,4 @@ anyhow.workspace = true
 clap.workspace = true
 inquire.workspace = true
 serde_json.workspace = true
-forgeguard-core = { version = "0.9.0", path = "../forgeguard-core" }
+forgeguard-core = { version = "0.10.0", path = "../forgeguard-core" }

--- a/crates/forgeguard-core/assets/skills/engineering/SKILL.md
+++ b/crates/forgeguard-core/assets/skills/engineering/SKILL.md
@@ -1,28 +1,67 @@
 ---
 name: forgeguard-engineering
-description: Enforce evidence-based engineering for backend, frontend, mobile, AI, scripts, infrastructure, APIs, components, queries, algorithms, and MCP work in any language or framework. Use whenever code or repository behavior changes.
+description: Enforce minimal, surgical, evidence-based engineering for backend, frontend, mobile, LLM, machine learning, deep learning, scripts, APIs, components, queries, algorithms, and MCP work. Use whenever code or repository behavior changes.
 ---
 
 # ForgeGuard Engineering
 
 Follow: inspect → design → implement → test → review → verify.
 
-Inspect the affected code, callers, tests, contracts, and schemas before editing. Reuse only behavior with the same purpose and change reasons; inspect every caller before changing shared behavior. Define relevant bounds, failures, complexity, I/O, concurrency, and the smallest safe design.
+## Work surgically
 
-For every code change in strict mode, and every non-trivial code change in other modes, use the ForgeGuard session id injected by the lifecycle hook to register the exact objective, verifiable todos, and optional path prefixes with `forgeguard task start`. For abstract work, also state the metric, baseline, target, guardrails, and verification so progress is hill-climbable. Keep the declared scope honest; expand it only after repository evidence shows the objective requires another path. Use `--semantic` only when the host provides a native goal evaluator.
+- Inspect the affected code, tests, contracts, schemas, direct callers, and compatibility surface before editing.
+- Resolve missing facts with read-only inspection. When unresolved ambiguity materially changes behavior, data, security, scope, cost, or external or irreversible state, use the host's native structured user-input tool and wait; otherwise state the safest reversible assumption.
+- Reuse an existing project pattern only when its purpose and change reasons match. Prefer the standard library and installed dependencies over new abstractions or packages.
+- Make every changed line trace to the objective. Do not refactor adjacent code or remove pre-existing dead code; remove only orphans created by the change.
+- Choose the smallest safe design. Define only the relevant bounds, failures, complexity, I/O, and concurrency risks.
 
-Implement focused changes and proportionate tests. Run `forgeguard gate --changed --output compact` plus relevant repository checks, review the complete diff, and report only executed checks and unresolved risk. Never weaken quality or security controls.
+## Register the goal
 
-Update completed todos with `forgeguard task todo`. Before stopping, run `forgeguard task ready --session <id> --confidence <0-100> --evidence <exact-check-result>` for an active task. Confidence is model-reported and advisory; it never replaces executed evidence. Never present a model-derived value, correction, or completion claim as fact: cite exact tool/check evidence or label the claim unverified.
+Use the session id injected by the lifecycle hook. Run `forgeguard mode` to resolve policy: register every change in strict mode and every non-trivial change otherwise.
 
-Treat an auto-poke as a new bounded verification phase: perform the requested TODO, test, review, or contract check, then submit fresh evidence. Do not repeat an earlier completion claim.
+Before editing, inspect existing state with `forgeguard task status --session <id>`. If no task exists, register the objective and verifiable steps:
 
-Read only the matching reference; do not read references for routine inspection, reuse, or testing:
+```sh
+forgeguard task start --session <id> --objective "<outcome>" \
+  --todo "<step with observable completion>" \
+  --verification "<exact check>"
+```
+
+Make every non-trivial goal hill-climbable: supply `--metric`, a measured `--baseline`, `--target`, at least one `--guardrail`, and `--verification`. For functional work, use an observable acceptance or regression count; never invent a baseline. Add `--scope <path>` when the affected paths are known. Use `--semantic` only when the host provides a native goal evaluator.
+
+## Prove the change
+
+Implement the smallest focused change and the smallest test layer that can fail for the changed behavior. Match evidence to the claim:
+
+- Bug fix: regression test exercising the reported failure.
+- API or schema change: contract, migration, or compatibility check.
+- Performance change: the same benchmark before and after, including the measured values.
+- Security or authorization change: negative-path test showing rejection.
+- Behavior-preserving refactor: relevant checks passing before and after.
+
+Never weaken tests, quality gates, validation, authorization, or security controls to pass a check.
+
+## Finish with evidence
+
+1. Run relevant repository checks and `forgeguard gate --changed --output compact`.
+2. Review the complete diff for unrelated edits and new dead code.
+3. Mark completed work with `forgeguard task todo --session <id> --done <index>`.
+4. Recheck `forgeguard task status --session <id>`; do not claim completion with pending todos.
+5. Submit each exact result with `forgeguard task ready --session <id> --confidence <0-100> --evidence "<check: result>"`.
+
+Report only executed evidence and unresolved risk. Confidence is advisory and never replaces deterministic evidence. Label unverified claims as unverified.
+
+Treat an auto-poke as a new bounded verification phase: perform the requested TODO or check, then submit fresh evidence. Do not repeat an earlier completion claim.
+
+Use progressive disclosure: read only the matching reference; do not read references for routine inspection, reuse, or testing. Role text is a reasoning frame, not permission to invent requirements, APIs, schemas, or evidence.
 
 - UI, browser client, or accessibility work: [frontend.md](references/frontend.md)
 - Native or cross-platform mobile work: [mobile.md](references/mobile.md)
 - API, service, auth, or distributed-operation work: [backend.md](references/backend.md)
-- Schema, query, migration, ORM, or MCP data work: [database.md](references/database.md)
-- LLM, RAG, agent, or MCP tool work: [ai.md](references/ai.md)
+- Schema, query, migration, ORM, or database MCP work: [database.md](references/database.md)
+- LLM, RAG, agent, or tool-authorization work: [ai.md](references/ai.md)
+- Classical machine-learning model or feature-pipeline work: [ml.md](references/ml.md)
+- Neural-network or deep-learning training/inference work: [deep-learning.md](references/deep-learning.md)
+- Model serving, deployment, registry, or drift-monitoring work: [mlops.md](references/mlops.md)
 - Data structures, measurable performance, fan-out, batching, or concurrency design: [algorithms.md](references/algorithms.md)
 - Complex, risky, or unfamiliar test design: [testing.md](references/testing.md)

--- a/crates/forgeguard-core/assets/skills/engineering/references/ai.md
+++ b/crates/forgeguard-core/assets/skills/engineering/references/ai.md
@@ -1,12 +1,9 @@
-# AI Engineering
+# LLM and Agent Engineering
 
-Act as a Senior AI Engineer. Treat model and tool output as untrusted data.
+Act as a senior AI application engineer responsible for trustworthy, bounded, observable, and secure model-assisted behavior.
 
-- Centralize provider integration at the appropriate scope with explicit model, timeout, retry, rate-limit, token, usage, and fallback policies.
-- Validate structured output with a schema and business rules before writes, tools, commands, or trusted rendering.
-- Version production prompts and define input/output contracts.
-- Treat self-corrections as new claims: require exact tool, calculation, or source evidence before presenting revised values as facts.
-- Treat model confidence as advisory history, never as proof or a replacement for deterministic evidence.
-- For agents and MCP, validate arguments, separate read/write capability, enforce allowlists, iteration limits, timeouts, audit logs, idempotency, and destructive-action policy.
+- Treat model and tool output as untrusted data, not authority. Validate schemas, business rules, permissions, and refusal paths before writes, tools, commands, or trusted rendering.
+- Version production prompts and define input/output contracts, model, timeout, retry, rate-limit, token, cost, and fallback policies.
+- For agents and MCP, separate read/write capability; enforce allowlists, iteration limits, timeouts, audit logs, idempotency, and destructive-action confirmation.
 - For RAG, enforce permissions, tenant filters, chunk metadata, embedding consistency, retrieval evaluation, citations, and stale-index handling.
-- Bound concurrency, deduplicate requests, cache only when safe, and measure latency, tokens, cost, schema validity, faithfulness, relevance, and regressions.
+- Measure latency, tokens, cost, schema validity, faithfulness, relevance, and regressions. Do not present model confidence as proof.

--- a/crates/forgeguard-core/assets/skills/engineering/references/backend.md
+++ b/crates/forgeguard-core/assets/skills/engineering/references/backend.md
@@ -1,5 +1,6 @@
 # Backend Engineering
 
-- Keep transport handlers thin and business rules in the appropriate application or domain layer.
-- Validate external input, authorize at the correct boundary, and return consistent errors without leaking internals.
-- Review idempotency, atomicity, transaction scope, pagination, timeouts, retries, partial failures, races, tenant isolation, and compatibility.
+- Trace the request from transport through authorization, business rules, persistence, and external calls before choosing the edit point.
+- Validate external input and authorize the target resource at the trust boundary. Return existing error shapes without leaking internals.
+- Review only relevant distributed risks: idempotency, atomicity, transaction scope, pagination, timeouts, retries, partial failures, races, tenant isolation, and compatibility.
+- Prove changed behavior at its boundary: request/response contract, authorization rejection, persistence effect, or idempotent retry.

--- a/crates/forgeguard-core/assets/skills/engineering/references/deep-learning.md
+++ b/crates/forgeguard-core/assets/skills/engineering/references/deep-learning.md
@@ -1,0 +1,9 @@
+# Deep Learning Engineering
+
+Act as a senior deep-learning engineer responsible for model correctness, training stability, reproducibility, and resource efficiency.
+
+- Verify tensor shapes, dtypes, device placement, preprocessing parity, labels, loss, output activation, and gradient flow.
+- Check NaN/Inf loss, exploding or vanishing gradients, overfitting, checkpoint recovery, and deterministic seed behavior.
+- Bound batch size, sequence/image dimensions, GPU memory, workers, training time, and checkpoint storage.
+- Compare architecture or hyperparameter changes against a fixed baseline with the same split and evaluation protocol.
+- Test serialization and inference separately from training. Do not claim improvement without untouched evaluation evidence and measured resource impact when relevant.

--- a/crates/forgeguard-core/assets/skills/engineering/references/frontend.md
+++ b/crates/forgeguard-core/assets/skills/engineering/references/frontend.md
@@ -1,11 +1,9 @@
 # Frontend Engineering
 
-Act as a Senior Frontend Engineer.
-
 - Search for existing components, hooks, API clients, validators, tokens, and formatters first.
 - Use the narrowest component scope: page-local, feature-shared, domain-shared, then design system.
 - Extract repeated components only when purpose, behavior, accessibility, lifecycle, and interface match.
 - Avoid components controlled by unrelated boolean flags and avoid duplicated business logic.
 - Cover loading, empty, error, success, disabled, duplicate-submit, responsive, keyboard, focus, screen-reader, and validation states.
 - Optimize rendering only from evidence. Do not add memoization mechanically.
-- Add component and interaction tests for changed behavior.
+- Verify changed behavior at the smallest layer that proves state transitions and user interaction; use browser or accessibility checks when DOM behavior is the contract.

--- a/crates/forgeguard-core/assets/skills/engineering/references/ml.md
+++ b/crates/forgeguard-core/assets/skills/engineering/references/ml.md
@@ -1,0 +1,9 @@
+# Machine Learning Engineering
+
+Act as a senior machine-learning engineer responsible for data validity, scientific evaluation, reproducibility, and decision quality.
+
+- Verify target, unit of analysis, provenance, labels, missingness, duplicates, class balance, and leakage before modeling.
+- Match random, grouped, stratified, or temporal splits to deployment reality; establish a simple baseline before changing features or models.
+- Select metrics according to error costs; check calibration and relevant subgroups when decisions require it.
+- Version data, features, preprocessing, split, seed policy, code, and environment across experiments.
+- Evaluate on untouched data. Do not claim improvement from training metrics alone; report the exact dataset/split, baseline, candidate metrics, and verification command.

--- a/crates/forgeguard-core/assets/skills/engineering/references/mlops.md
+++ b/crates/forgeguard-core/assets/skills/engineering/references/mlops.md
@@ -1,0 +1,9 @@
+# MLOps and Model Serving
+
+Act as a senior MLOps engineer responsible for reproducible delivery, training-serving consistency, safe rollout, observability, and rollback.
+
+- Version and verify model artifacts, data, preprocessing, code, dependencies, and runtime together.
+- Test batch and online inference for schema, shape, latency, throughput, resource limits, and training-serving skew.
+- Use approval gates, immutable artifacts, canary or shadow rollout, rollback, and access controls for production models.
+- Monitor data quality, drift, prediction distribution, performance proxies, cost, and failures; define alert and retraining boundaries.
+- Report the deployed artifact identity, exact verification checks, measured limits, and unresolved operational risk.

--- a/crates/forgeguard-core/assets/skills/engineering/references/mobile.md
+++ b/crates/forgeguard-core/assets/skills/engineering/references/mobile.md
@@ -1,11 +1,9 @@
 # Mobile Engineering
 
-Act as a Senior Mobile Engineer for native or cross-platform work.
-
 - Inspect existing navigation, state, networking, persistence, design system, and platform conventions.
 - Reuse components only when behavior, lifecycle, accessibility, and platform semantics match.
 - Handle loading, empty, offline, retry, permission denial, backgrounding, restoration, and interrupted flows.
 - Bound memory, network work, listeners, subscriptions, and background tasks; measure startup, frame, and battery impact when relevant.
 - Protect secrets and local data; validate deep links, intents, push payloads, and untrusted API/model output.
 - Preserve iOS/Android conventions instead of forcing identical behavior where platforms differ.
-- Test business logic, state transitions, accessibility, device boundaries, and critical user flows.
+- Match evidence to the change: state tests for business transitions, device or platform checks for lifecycle and permission behavior, and accessibility checks for changed interaction.

--- a/crates/forgeguard-core/assets/skills/engineering/references/testing.md
+++ b/crates/forgeguard-core/assets/skills/engineering/references/testing.md
@@ -2,5 +2,6 @@
 
 - Select the smallest test layer that proves the changed behavior; add integration, contract, or regression coverage when the boundary or risk requires it.
 - Cover relevant invalid input, boundaries, empty values, errors, permissions, duplicates, and concurrency.
+- Prefer one regression test for the root cause over guards repeated across callers. Verify public behavior rather than private implementation details.
 - Preserve meaningful assertions; never skip or weaken them solely to make a check pass.
 - When a check cannot run, inspect its output and report the exact blocker and remaining command.

--- a/crates/forgeguard-core/src/hook.rs
+++ b/crates/forgeguard-core/src/hook.rs
@@ -50,6 +50,7 @@ const AUTO_POKE_PHASES: [&str; 5] = [
     "verify contracts, edge cases, and failure handling against repository evidence",
     "run final verification and confirm no objective gap remains",
 ];
+const CLARIFICATION_CONTEXT: &str = "Before acting, resolve missing facts with read-only inspection. If unresolved ambiguity materially changes behavior, data, security, scope, cost, or external or irreversible state, {question_instruction} and wait for the answer. Otherwise use the safest reversible default and state it briefly.";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookAgent {
@@ -555,12 +556,23 @@ pub fn evaluate_context_hook(
     {
         return Ok(None);
     }
-    Ok(Some(match task {
+    let mut context = match task {
         Some(task) => task_context(&task),
         None => format!(
             "ForgeGuard focus session {session}. For non-trivial code changes, register the objective and verifiable todos before editing: `forgeguard task start --session {session} --objective <goal> --todo <step> [--metric <metric> --baseline <value> --target <value> --verification <check>]`. Never state a correction, number, or completion claim without exact tool/check evidence; label it unverified otherwise."
         ),
-    }))
+    };
+    let question_instruction = match agent {
+        HookAgent::Claude => "call `AskUserQuestion`",
+        HookAgent::Codex => "use `request_user_input` when available, otherwise ask directly",
+        HookAgent::Cursor | HookAgent::Antigravity => {
+            "use the host's native structured user-input tool when available, otherwise ask directly"
+        }
+    };
+    context.push(' ');
+    context
+        .push_str(&CLARIFICATION_CONTEXT.replace("{question_instruction}", question_instruction));
+    Ok(Some(context))
 }
 
 pub fn render_context_hook(agent: HookAgent, input: &str, context: &str) -> String {

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -68,6 +68,18 @@ const SKILL_ASSETS: &[(&str, &str)] = &[
         include_str!("../assets/skills/engineering/references/ai.md"),
     ),
     (
+        "references/ml.md",
+        include_str!("../assets/skills/engineering/references/ml.md"),
+    ),
+    (
+        "references/deep-learning.md",
+        include_str!("../assets/skills/engineering/references/deep-learning.md"),
+    ),
+    (
+        "references/mlops.md",
+        include_str!("../assets/skills/engineering/references/mlops.md"),
+    ),
+    (
         "references/testing.md",
         include_str!("../assets/skills/engineering/references/testing.md"),
     ),
@@ -422,6 +434,15 @@ fn install_claude(
     install_grouped_hook(
         root,
         &root.join(".claude/settings.json"),
+        "UserPromptSubmit",
+        None,
+        CLAUDE_CONTEXT_HOOK_COMMAND,
+        written,
+        skipped,
+    )?;
+    install_grouped_hook(
+        root,
+        &root.join(".claude/settings.json"),
         "PreToolUse",
         Some("Edit|Write|MultiEdit|NotebookEdit"),
         CLAUDE_SCOPE_HOOK_COMMAND,
@@ -660,7 +681,10 @@ fn install_grouped_hook(
     skipped: &mut Vec<String>,
 ) -> Result<()> {
     let mut document = read_json_object(path)?;
-    if contains_string(&document, command) {
+    if document
+        .pointer(&format!("/hooks/{event}"))
+        .is_some_and(|hooks| contains_hook_command(hooks, command))
+    {
         record_path(root, path, skipped);
         return Ok(());
     }
@@ -821,6 +845,19 @@ fn contains_string(value: &Value, expected: &str) -> bool {
         Value::Object(values) => values
             .values()
             .any(|value| contains_string(value, expected)),
+        _ => false,
+    }
+}
+
+fn contains_hook_command(value: &Value, expected: &str) -> bool {
+    match value {
+        Value::String(value) => value.contains(expected),
+        Value::Array(values) => values
+            .iter()
+            .any(|value| contains_hook_command(value, expected)),
+        Value::Object(values) => values
+            .values()
+            .any(|value| contains_hook_command(value, expected)),
         _ => false,
     }
 }

--- a/crates/forgeguard-core/tests/hook_test.rs
+++ b/crates/forgeguard-core/tests/hook_test.rs
@@ -483,6 +483,32 @@ fn task_context_is_session_scoped_and_scope_drift_is_warned() {
 }
 
 #[test]
+fn agent_context_requires_questions_only_for_material_ambiguity() {
+    let directory = tempdir().expect("temp directory");
+    git_init(directory.path());
+    ForgeGuardConfig::new("sample", Vec::new())
+        .save(directory.path())
+        .expect("save config");
+    let input = format!(
+        r#"{{"cwd":"{}","session_id":"clarify","hook_event_name":"UserPromptSubmit"}}"#,
+        directory.path().display()
+    );
+
+    for (agent, expected) in [
+        (HookAgent::Claude, "call `AskUserQuestion`"),
+        (HookAgent::Codex, "use `request_user_input` when available"),
+        (HookAgent::Cursor, "native structured user-input tool"),
+        (HookAgent::Antigravity, "native structured user-input tool"),
+    ] {
+        let context = evaluate_context_hook(directory.path(), &input, agent)
+            .expect("evaluate agent context")
+            .expect("agent context");
+        assert!(context.contains(expected));
+        assert!(context.contains("safest reversible default"));
+    }
+}
+
+#[test]
 fn stop_retry_budget_is_isolated_by_session() {
     let directory = tempdir().expect("temp directory");
     git_init(directory.path());

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -61,6 +61,18 @@ fn installs_configuration_for_all_supported_agents() {
         .exists());
     assert!(directory
         .path()
+        .join(".agents/skills/forgeguard-engineering/references/ml.md")
+        .exists());
+    assert!(directory
+        .path()
+        .join(".claude/skills/forgeguard-engineering/references/deep-learning.md")
+        .exists());
+    assert!(directory
+        .path()
+        .join(".agents/skills/forgeguard-engineering/references/mlops.md")
+        .exists());
+    assert!(directory
+        .path()
         .join(".agents/skills/forgeguard-engineering/references/mobile.md")
         .exists());
     assert!(!directory.path().join(".gitignore").exists());
@@ -94,6 +106,17 @@ fn installs_configuration_for_all_supported_agents() {
     );
     assert_eq!(
         codex_hooks["hooks"]["PreToolUse"].as_array().map(Vec::len),
+        Some(1)
+    );
+    let claude_hooks: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(directory.path().join(".claude/settings.json"))
+            .expect("read Claude hooks"),
+    )
+    .expect("parse Claude hooks");
+    assert_eq!(
+        claude_hooks["hooks"]["UserPromptSubmit"]
+            .as_array()
+            .map(Vec::len),
         Some(1)
     );
     assert!(!report.files_written.is_empty());
@@ -282,7 +305,7 @@ fn hook_install_preserves_existing_settings_and_is_idempotent() {
     fs::create_dir_all(settings.parent().expect("settings parent")).expect("create settings");
     fs::write(
         &settings,
-        r#"{"permissions":{"allow":["Bash(git status)"]},"hooks":{"Stop":[]}}"#,
+        r#"{"permissions":{"allow":["Bash(git status)"]},"hooks":{"Stop":[],"SessionStart":[{"hooks":[{"type":"command","command":"repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0; forgeguard hook context --agent claude --root \"$repo_root\""}]}]}}"#,
     )
     .expect("write settings");
 
@@ -311,7 +334,15 @@ fn hook_install_preserves_existing_settings_and_is_idempotent() {
         source
             .matches("forgeguard hook context --agent claude")
             .count(),
-        1
+        2
+    );
+    assert_eq!(
+        value["hooks"]["SessionStart"].as_array().map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        value["hooks"]["UserPromptSubmit"].as_array().map(Vec::len),
+        Some(1)
     );
     assert_eq!(
         source
@@ -430,6 +461,13 @@ fn opencode_target_uses_shared_standards_without_unrelated_hooks() {
         .path()
         .join(".agents/skills/forgeguard-engineering/SKILL.md")
         .exists());
+    assert!(fs::read_to_string(
+        directory
+            .path()
+            .join(".agents/skills/forgeguard-engineering/SKILL.md")
+    )
+    .expect("read OpenCode skill")
+    .contains("native structured user-input tool"));
     assert!(!directory.path().join(".codex/hooks.json").exists());
     assert!(!directory.path().join(".agents/hooks.json").exists());
 }


### PR DESCRIPTION
## What changed

- add material-ambiguity confirmation guidance across Claude, Codex, Cursor, Antigravity, and OpenCode
- refresh Claude guidance on every `UserPromptSubmit` while preserving supported lifecycle behavior elsewhere
- expand the engineering skill with focused ML, deep-learning, and MLOps references
- package all linked skill references and deduplicate wrapped hook commands
- bump the workspace release version to 0.10.0

## Why

Non-Claude model gateways can skip structured clarification and silently assume consequential choices. ForgeGuard now reinforces native user-input tools at supported lifecycle points without interrupting safe, reversible defaults.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace`
- `forgeguard gate --changed --output compact`
