### PR TITLE
fix: target release package crate

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  ".": "0.10.0"
+  "crates/forgeguard-cli": "0.10.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "release-type": "rust",
   "include-component-in-tag": false,
   "packages": {
-    ".": {
+    "crates/forgeguard-cli": {
       "package-name": "forgeguard",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary

Fix Release Please manifest mode for the Cargo workspace.

## Changes

- Point the configured release package at `crates/forgeguard-cli`.
- Keep `npm/package.json` synchronized as an extra version file.

## Test plan

- [x] JSON configuration parses successfully.
- [x] Release Please CLI is available and configuration was checked locally.

The previous Release Please run failed because the root Cargo manifest is a workspace manifest without a `[package]` version.