### PR TITLE
feat: add update policy gate (auto/ask/off)

### DIFF
--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use forgeguard_core::{
-    config::{ForgeGuardConfig, CONFIG_FILE},
+    config::{ForgeGuardConfig, UpdatePolicy, CONFIG_FILE},
     create_baseline_with_config, detect_project, evaluate_context_hook, evaluate_scope_hook,
     evaluate_stop_hook,
     git::changed_files,
@@ -115,12 +115,20 @@ enum Commands {
         #[command(subcommand)]
         command: Box<TaskCommands>,
     },
-    /// Check for a newer release (checks only; installs nothing).
+    /// Check for a newer release, or change the update policy.
     ///
-    /// Only checks and prints a notice; it installs nothing. To upgrade, re-run
-    /// the installer, then `forgeguard init --force` to refresh skills and
-    /// policies. Use `forgeguard --version` to see the installed version.
-    Update,
+    /// With no `--mode`, checks and prints a notice; `auto`/`off` never
+    /// install anything. `ask` mode also gates other TTY-run commands
+    /// (`init`, `doctor`, `gate`, `review`, `baseline`) with a y/n prompt
+    /// when a newer version is cached, and installs only on explicit "yes".
+    Update {
+        #[arg(long, value_enum)]
+        mode: Option<UpdatePolicyArg>,
+        #[arg(long)]
+        global: bool,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -147,6 +155,23 @@ enum ModeArg {
     Default,
     Lite,
     Strict,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum UpdatePolicyArg {
+    Auto,
+    Ask,
+    Off,
+}
+
+impl From<UpdatePolicyArg> for UpdatePolicy {
+    fn from(value: UpdatePolicyArg) -> Self {
+        match value {
+            UpdatePolicyArg::Auto => UpdatePolicy::Auto,
+            UpdatePolicyArg::Ask => UpdatePolicy::Ask,
+            UpdatePolicyArg::Off => UpdatePolicy::Off,
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -335,7 +360,7 @@ fn execute() -> Result<ExitCode> {
                 }
             }
             if !json {
-                print_update_notice();
+                maybe_gate_update(&root)?;
             }
             Ok(ExitCode::SUCCESS)
         }
@@ -403,7 +428,7 @@ fn execute() -> Result<ExitCode> {
                 println!("{}", serde_json::to_string_pretty(&report)?);
             } else {
                 print!("{}", render_doctor(&report));
-                print_update_notice();
+                maybe_gate_update(&root)?;
             }
             Ok(if report.healthy {
                 ExitCode::SUCCESS
@@ -420,6 +445,9 @@ fn execute() -> Result<ExitCode> {
             let config = ForgeGuardConfig::load(&root).context(
                 "ForgeGuard is not initialized; run `forgeguard init` in the repository first",
             )?;
+            if !json {
+                maybe_gate_update(&root)?;
+            }
             let paths = if changed {
                 Some(changed_files(&root)?)
             } else {
@@ -440,6 +468,9 @@ fn execute() -> Result<ExitCode> {
             let config = ForgeGuardConfig::load(&root).context(
                 "ForgeGuard is not initialized; run `forgeguard init` in the repository first",
             )?;
+            if !json {
+                maybe_gate_update(&root)?;
+            }
             let paths = Some(changed_files(&root)?);
             let report = run_gate(
                 &root,
@@ -458,6 +489,9 @@ fn execute() -> Result<ExitCode> {
             let config = ForgeGuardConfig::load(&root).context(
                 "ForgeGuard is not initialized; run `forgeguard init` in the repository first",
             )?;
+            if !json {
+                maybe_gate_update(&root)?;
+            }
             let baseline = create_baseline_with_config(&root, &config, force)?;
             if json {
                 println!(
@@ -485,18 +519,52 @@ fn execute() -> Result<ExitCode> {
             command: HookCommands::Scope { agent },
         } => execute_scope_hook(&root, agent.into()),
         Commands::Task { command } => execute_task(&root, *command),
-        Commands::Update => {
-            let home = home_directory()?;
-            match forgeguard_core::update::refresh(&home, true) {
-                Some(notice) => println!("{notice}"),
-                None => println!(
-                    "ForgeGuard {} is up to date.",
-                    forgeguard_core::update::current_version()
-                ),
-            }
-            Ok(ExitCode::SUCCESS)
-        }
+        Commands::Update { mode, global, json } => execute_update(&root, mode, global, json),
     }
+}
+
+fn execute_update(
+    root: &Path,
+    mode: Option<UpdatePolicyArg>,
+    global: bool,
+    json: bool,
+) -> Result<ExitCode> {
+    if let Some(mode) = mode {
+        let target = if global {
+            home_directory()?
+        } else {
+            root.to_path_buf()
+        };
+        let mut config = load_or_create_config(&target, global)?;
+        config.update.policy = mode.into();
+        save_config(&target, global, &config)?;
+        if json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "scope": if global { "global" } else { "project" },
+                    "update_policy": config.update.policy.as_str(),
+                })
+            );
+        } else {
+            println!(
+                "ForgeGuard {} update policy set to {}.",
+                if global { "global" } else { "project" },
+                config.update.policy.as_str()
+            );
+        }
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let home = home_directory()?;
+    match forgeguard_core::update::refresh(&home, true) {
+        Some(notice) => println!("{notice}"),
+        None => println!(
+            "ForgeGuard {} is up to date.",
+            forgeguard_core::update::current_version()
+        ),
+    }
+    Ok(ExitCode::SUCCESS)
 }
 
 fn execute_mode(root: &Path, mode: Option<ModeArg>, global: bool, json: bool) -> Result<ExitCode> {
@@ -741,6 +809,49 @@ fn print_update_notice() {
             println!("{notice}");
         }
     }
+}
+
+/// Project config wins over global config when both set an update policy;
+/// falls back to `auto` when neither is initialized.
+fn resolve_update_policy(root: &Path, home: &Path) -> UpdatePolicy {
+    if let Ok(config) = ForgeGuardConfig::load(root) {
+        return config.update.policy;
+    }
+    if let Ok(config) = ForgeGuardConfig::load_global(home) {
+        return config.update.policy;
+    }
+    UpdatePolicy::Auto
+}
+
+/// Surface the update notice according to the resolved policy. `auto` stays
+/// passive (current behavior); `ask` blocks with a y/n prompt on a real TTY
+/// and, on "yes", runs the installer; `off` skips the check entirely. Never
+/// blocks a non-interactive run (falls back to passive notice).
+fn maybe_gate_update(root: &Path) -> Result<()> {
+    let Ok(home) = home_directory() else {
+        return Ok(());
+    };
+    match resolve_update_policy(root, &home) {
+        UpdatePolicy::Off => {}
+        UpdatePolicy::Auto => print_update_notice(),
+        UpdatePolicy::Ask if io::stdin().is_terminal() => {
+            if let Some(notice) = forgeguard_core::update::refresh(&home, false) {
+                println!("{notice}");
+                print!("Update now? [y/N]: ");
+                io::stdout().flush()?;
+                let mut input = String::new();
+                io::stdin().read_line(&mut input)?;
+                if matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+                    let status = forgeguard_core::update::run_install_command()?;
+                    if !status.success() {
+                        eprintln!("ForgeGuard update command exited with {status}.");
+                    }
+                }
+            }
+        }
+        UpdatePolicy::Ask => print_update_notice(),
+    }
+    Ok(())
 }
 
 fn render_gate_output(report: &GateReport, json: bool, output: OutputArg) -> Result<()> {

--- a/crates/forgeguard-core/src/config.rs
+++ b/crates/forgeguard-core/src/config.rs
@@ -32,6 +32,34 @@ impl GuardMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum UpdatePolicy {
+    /// Refresh the cache and print a passive notice; never prompts or installs.
+    #[default]
+    Auto,
+    /// Prompt to update on TTY-run commands when a newer version is cached.
+    Ask,
+    /// Skip the update check entirely.
+    Off,
+}
+
+impl UpdatePolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Ask => "ask",
+            Self::Off => "off",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct UpdateConfig {
+    #[serde(default)]
+    pub policy: UpdatePolicy,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProjectConfig {
     pub name: String,
@@ -142,6 +170,8 @@ pub struct ForgeGuardConfig {
     pub policies: PolicyConfig,
     #[serde(default)]
     pub rules: BTreeMap<String, RuleConfig>,
+    #[serde(default)]
+    pub update: UpdateConfig,
 }
 
 impl ForgeGuardConfig {
@@ -157,6 +187,7 @@ impl ForgeGuardConfig {
             focus: FocusConfig::default(),
             policies: PolicyConfig::default(),
             rules: BTreeMap::new(),
+            update: UpdateConfig::default(),
         }
     }
 
@@ -280,4 +311,33 @@ fn default_focus_min_confidence() -> u8 {
 
 fn default_focus_min_hill_climbability() -> u8 {
     80
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_without_update_section_defaults_to_auto_policy() {
+        let toml_source = r#"
+version = 2
+[project]
+name = "demo"
+"#;
+        let config: ForgeGuardConfig = toml::from_str(toml_source).unwrap();
+        assert_eq!(config.update.policy, UpdatePolicy::Auto);
+    }
+
+    #[test]
+    fn update_policy_round_trips_through_toml() {
+        let config = ForgeGuardConfig {
+            update: UpdateConfig {
+                policy: UpdatePolicy::Ask,
+            },
+            ..ForgeGuardConfig::new("demo", Vec::new())
+        };
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let parsed: ForgeGuardConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(parsed.update.policy, UpdatePolicy::Ask);
+    }
 }

--- a/crates/forgeguard-core/src/update.rs
+++ b/crates/forgeguard-core/src/update.rs
@@ -7,9 +7,9 @@
 //! API token, or rate-limited endpoint is required.
 
 use std::{
-    fs,
+    fs, io,
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Command, ExitStatus, Stdio},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -72,6 +72,20 @@ pub fn spawn_refresh_if_stale(home: &Path) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn();
+}
+
+/// Run the same installer a user would invoke by hand
+/// (`curl -fsSL .../install.sh | sh`), with inherited stdio so install output
+/// is visible. Used only when a user has explicitly confirmed an `ask`-mode
+/// update prompt; never called automatically.
+pub fn run_install_command() -> io::Result<ExitStatus> {
+    Command::new("sh")
+        .arg("-c")
+        .arg(INSTALL_COMMAND)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
 }
 
 fn is_stale(home: &Path) -> bool {


### PR DESCRIPTION
## Summary
- Update notice was passive-only; add a configurable policy so users can choose to just be notified or actually get prompted to update.
- Default stays non-disruptive (`auto`); opt-in `ask` mode gates human-run commands.

## Changes
- `forgeguard-core/config.rs`: new `update.policy` field (`auto`/`ask`/`off`), defaults to `auto`, backward-compatible with existing config files.
- `forgeguard-core/update.rs`: `run_install_command()` shells out to the existing `install.sh` installer (only called on explicit user confirmation).
- `forgeguard-cli/main.rs`: `forgeguard update --mode <auto|ask|off> [--global]` sets/persists the policy; `init`/`doctor`/`gate`/`review`/`baseline` are gated via `maybe_gate_update` when on a real TTY and policy is `ask`. Stop hook untouched (fire-and-forget, no interactive stdin available there).

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all pass, incl. new config round-trip tests)
- [x] `cargo fmt --all` (clean)
- [x] Manual: `forgeguard update --mode ask --global` persists to `~/.forgeguard/config.toml`
- [x] Manual: `ask` mode with no TTY falls back to passive notice, doesn't hang
- [x] Manual: `off` mode suppresses the notice entirely