### PR TITLE
fix: pin literal version in released crate's Cargo.toml

### DIFF
--- a/crates/forgeguard-cli/Cargo.toml
+++ b/crates/forgeguard-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forgeguard"
-version.workspace = true
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary
- Manual release-please trigger failed on every run: `release-please failed: value at path package.version is not tagged`.
- Root cause: `crates/forgeguard-cli/Cargo.toml` used `version.workspace = true`; release-please's rust strategy needs a literal semver string at `package.version` to read/bump it, and can't with workspace inheritance.

## Changes
- `crates/forgeguard-cli/Cargo.toml`: `version.workspace = true` → `version = "0.10.0"` (matches the workspace version it was inheriting, no behavior change).

## Test plan
- [x] `cargo build --workspace`
- [x] `./target/debug/forgeguard --version` still reports `forgeguard 0.10.0`
- [ ] Re-trigger release-please manually after merge, confirm it opens/updates the release PR instead of failing