### PR TITLE
fix: repair release-please pipeline and enable npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,36 @@
+name: npm-publish
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify release tag matches package version
+        shell: bash
+        run: |
+          package_version="$(node -p "require('./npm/package.json').version")"
+          test "${{ github.event.workflow_run.head_branch }}" = "v$package_version"
+      # Trusted Publishing (OIDC): no NPM_TOKEN needed. Requires npm >= 11.5.1
+      # and this exact workflow path registered as a Trusted Publisher on
+      # npmjs.com for @suiflex/forgeguard.
+      - run: npm install -g npm@latest
+      - run: npm publish --access public
+        working-directory: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Verify tag matches package version
         shell: bash
         run: |
-          package_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+          package_version="$(sed -n 's/^version = "\(.*\)"/\1/p' crates/forgeguard-cli/Cargo.toml | head -1)"
           test "${GITHUB_REF_NAME#v}" = "$package_version"
       - uses: dtolnay/rust-toolchain@788abdaa468b02b2d53a3d1d8fcac62dc9858f4a # stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,16 +4,16 @@
   "include-component-in-tag": false,
   "packages": {
     "crates/forgeguard-cli": {
-      "package-name": "forgeguard",
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "npm/package.json",
-          "jsonpath": "$.version"
-        }
-      ]
+      "package-name": "forgeguard"
     }
   },
+  "extra-files": [
+    {
+      "type": "json",
+      "path": "npm/package.json",
+      "jsonpath": "$.version"
+    }
+  ],
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Main branch CI broke right after merging release-please's 0.11.0 release PR: `cargo check --locked` failed because Cargo.lock still pinned `forgeguard 0.10.0`.
- Tracing that surfaced two more release-please integration bugs, plus the missing piece for `@suiflex/forgeguard` on npm: a Trusted Publisher is already registered on npmjs.com (OIDC, no token), but no workflow existed at the path it's registered against.

## Changes
- `Cargo.lock`: sync `forgeguard`'s locked version to `0.11.0` to match `crates/forgeguard-cli/Cargo.toml` (fixes the CI break directly).
- `release-please-config.json`: move the `npm/package.json` `extra-files` bump out from under the `crates/forgeguard-cli` package entry to the top level. Nested under the package, its path resolved to `crates/forgeguard-cli/npm/package.json` (never existed) — release-please silently skipped the bump every run, so `npm/package.json`'s version has been stuck at `0.10.0` regardless of the actual crate version.
- `.github/workflows/release.yml`: tag-verify step now reads `crates/forgeguard-cli/Cargo.toml` (the crate actually being tagged/released) instead of the root `Cargo.toml` (only the workspace default version, decoupled from the released crate since the previous version-pin fix).
- `.github/workflows/npm-publish.yml` (new): publishes `@suiflex/forgeguard` to npm via OIDC Trusted Publishing after `Release` completes successfully, so the GitHub Release binaries `scripts/install.js` downloads at postinstall exist before the matching npm version goes out. No `NPM_TOKEN` — `id-token: write` lets npm's CLI (>=11.5.1) handle the OIDC exchange itself. Re-checks the release tag against `npm/package.json`'s version before publishing.

## Test plan
- [x] `cargo check --locked --workspace` (the exact failing CI command) now passes
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `release-please-config.json` and `npm-publish.yml` validated as well-formed
- [ ] Confirm main's CI goes green after merge
- [ ] Confirm the next release-please run bumps `npm/package.json`
- [ ] Confirm the next tagged release triggers `npm-publish` and publishes successfully via OIDC