### PR TITLE
chore: force a 0.11.1 release to validate the fixed pipeline

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
   "include-component-in-tag": false,
   "packages": {
     "crates/forgeguard-cli": {
-      "package-name": "forgeguard"
+      "package-name": "forgeguard",
+      "release-as": "0.11.1"
     }
   },
   "extra-files": [


### PR DESCRIPTION
## Summary
- Nothing in `crates/forgeguard-cli` has changed since `0.11.0` (all of PR #35 touched root-level infra files), so release-please correctly finds no commits to release on its own.
- Neither the `Cargo.lock`/tag-verify fixes nor the new `npm-publish.yml` OIDC workflow have run end-to-end yet.

## Changes
- `release-please-config.json`: temporary `"release-as": "0.11.1"` override on the `crates/forgeguard-cli` package, forcing the next release-please run to open a release PR for that version despite the empty commit range.

## After merging this PR
1. Manually run `release-please` (`workflow_dispatch`) — should open a `chore(main): release 0.11.1` PR this time.
2. Merge that release PR → tags `v0.11.1` → `Release` workflow builds/verifies/publishes the GitHub Release.
3. `Release` completing successfully triggers `npm-publish` → publishes `@suiflex/forgeguard@0.11.1` via OIDC.
4. **Follow-up needed**: remove the `release-as` override from `release-please-config.json` afterward, so future releases resume normal conventional-commit-driven bumping instead of being pinned to `0.11.1` forever.

## Test plan
- [x] `release-please-config.json` validated as well-formed JSON
- [ ] release-please opens a release PR for 0.11.1 after merge
- [ ] main CI green after merging the release PR
- [ ] `npm-publish` run succeeds, `@suiflex/forgeguard@0.11.1` visible on the npm registry