### PR TITLE
chore: force 0.11.1 via empty commit (release-as config didn't work)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
   "include-component-in-tag": false,
   "packages": {
     "crates/forgeguard-cli": {
-      "package-name": "forgeguard",
-      "release-as": "0.11.1"
+      "package-name": "forgeguard"
     }
   },
   "extra-files": [


### PR DESCRIPTION
## Summary
- PR #36's `"release-as": "0.11.1"` package-config override did **not** work — verified after merging it and re-running release-please: still `commits: 0` / `No commits for path: crates/forgeguard-cli, skipping`. My earlier claim that it would was wrong; I hadn't checked it against release-please's actual source, just its config docs.
- Read `manifest.ts` and `util/commit-split.ts` from the release-please source: `release-as` in package config only overrides the *version* once a release is already being built from a non-empty commit list for that path — it doesn't bypass the empty-range skip. The mechanism that does is different: an empty commit (`git commit --allow-empty`) with a `Release-As: x.y.z` footer, because `CommitSplit` is constructed with `includeEmpty: true`, which applies any commit with zero changed files to *every* configured package path. This exact scenario is the documented example in `commit-split.ts`'s own source comments.

## Changes
- `release-please-config.json`: revert the `release-as` override from #36 — it doesn't achieve what we need, and left in place it would silently pin *every future* release to `0.11.1` regardless of real commits.
- One empty commit (`chore: force a 0.11.1 release...`) with a `Release-As: 0.11.1` footer, to trigger a real release-please PR for `crates/forgeguard-cli` despite no source changes.

## After merging this PR
1. Manually run `release-please` (`workflow_dispatch`).
2. Should open `chore(main): release 0.11.1` this time — will confirm before telling you it worked.
3. Merge that release PR → tag `v0.11.1` → `Release` workflow → `npm-publish` via OIDC.

## Test plan
- [x] Read release-please's `manifest.ts` / `util/commit-split.ts` source directly to confirm this mechanism before proposing it again
- [ ] release-please opens a release PR for 0.11.1 after merge (will verify via `gh run` logs, not assume)