### PR TITLE
fix: root-anchor the npm/package.json extra-files path

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
   "extra-files": [
     {
       "type": "json",
-      "path": "npm/package.json",
+      "path": "/npm/package.json",
       "jsonpath": "$.version"
     }
   ],


### PR DESCRIPTION
## Summary
- PR #37 moved `extra-files` for `npm/package.json` to the top level of `release-please-config.json`, expecting root-relative resolution. Checked the live run for PR #38 (open release PR): still `⚠ file crates/forgeguard-cli/npm/package.json did not exist`.
- Read `strategies/base.ts`'s `addPath()`: extraFiles entries are *always* prefixed with the owning strategy's package path (`crates/forgeguard-cli/`), whether the entry came from top-level or per-package config — top-level `extra-files` just becomes part of each package's merged config, it doesn't change path resolution. The only way to keep a path root-relative is a leading `/`, which `addPath()` explicitly special-cases.

## Changes
- `release-please-config.json`: `"path": "npm/package.json"` → `"path": "/npm/package.json"`.

## Notes
- release-please updates its existing bot-owned release branch/PR (#38) on each run rather than opening a new one, so re-running `release-please` after this merges should update PR #38 in place with the npm bump included — will verify from logs, not assume.
- Once PR #38 merges, `Cargo.lock` will need the same kind of manual sync PR #35 did (release-please's rust strategy doesn't manage workspace lockfiles) — will follow up right after.

## Test plan
- [x] `release-please-config.json` validated as well-formed JSON
- [x] Verified the root cause against release-please's actual source (`strategies/base.ts`), not just docs, after being wrong twice already
- [ ] Re-run release-please, confirm PR #38's diff includes `npm/package.json`'s version bump