### PR TITLE
fix: chain Release workflow into release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,9 @@ jobs:
       (github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release-please--'))
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs['crates/forgeguard-cli--release_created'] }}
+      tag_name: ${{ steps.release.outputs['crates/forgeguard-cli--tag_name'] }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,8 +31,18 @@ jobs:
           fetch-depth: 0
 
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           token: ${{ github.token }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  release:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,18 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_call:
+    inputs:
+      tag:
+        description: Git tag to build and publish (e.g. v0.11.1)
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Git tag to build and publish (e.g. v0.11.1)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,11 +24,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
       - name: Verify tag matches package version
         shell: bash
         run: |
+          tag="${{ inputs.tag || github.ref_name }}"
           package_version="$(sed -n 's/^version = "\(.*\)"/\1/p' crates/forgeguard-cli/Cargo.toml | head -1)"
-          test "${GITHUB_REF_NAME#v}" = "$package_version"
+          test "${tag#v}" = "$package_version"
       - uses: dtolnay/rust-toolchain@788abdaa468b02b2d53a3d1d8fcac62dc9858f4a # stable
         with:
           components: rustfmt, clippy
@@ -78,6 +93,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
       - uses: dtolnay/rust-toolchain@788abdaa468b02b2d53a3d1d8fcac62dc9858f4a # stable
         with:
           targets: ${{ matrix.target }}
@@ -123,5 +140,6 @@ jobs:
           merge-multiple: true
       - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: dist/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Summary
- `v0.11.1`'s GitHub Release (created when PR #38 merged) has **zero binary assets** — `Release` (release.yml) never ran for it, confirmed via `gh release view v0.11.1 --json assets` (empty) vs `v0.10.0` (12 files).
- Root cause, confirmed against GitHub's own docs (quoted directly in release-please-action's README, not inferred): resources created using the default `GITHUB_TOKEN` — including the tag `release-please-action` pushes — do not trigger other workflows' `push` events, specifically to prevent recursive runs. `release.yml`'s `on: push: tags: v*` was therefore never reachable from a release-please-created tag. It only worked for v0.8.x–v0.10.0 because those tags were presumably pushed by hand at some point, not exclusively by the bot.

## Changes
- `.github/workflows/release.yml`: added `workflow_call` (with a required `tag` input) and `workflow_dispatch` (same input, for manually backfilling a stuck release) triggers alongside the existing `push: tags: v*`. Checkout steps and the `softprops/action-gh-release` step now resolve the tag from `inputs.tag || github.ref_name`, since `github.ref_name` is the *caller's* ref (main) when invoked via `workflow_call`, not the release tag.
- `.github/workflows/release-please.yml`: the `release-please` job now has `id: release` and exposes `release_created`/`tag_name` as job outputs (path-prefixed per release-please-action's docs, since our package path is `crates/forgeguard-cli`, not root). A new `release` job runs `uses: ./.github/workflows/release.yml` gated on `release_created == 'true'`, in the *same workflow run* — no separate push event required, no new token/secret needed.

## After merging
`v0.11.1`'s release still has no assets and release-please won't re-emit `release_created` for an already-tagged version. Plan to manually run `release.yml` via `workflow_dispatch` with `tag: v0.11.1` once this merges, to backfill it — then verify assets actually appear and `npm-publish` fires, before reporting success.

## Test plan
- [x] Both workflow files validated as well-formed YAML
- [x] Root cause verified against GitHub's documented behavior and release-please-action's README, not guessed
- [ ] Manually dispatch `release.yml` for `v0.11.1`, confirm all 12 binary assets get uploaded
- [ ] Confirm `npm-publish` triggers afterward and `@suiflex/forgeguard@0.11.1` (or a subsequent version) publishes
- [ ] Confirm a *future* release-please-driven release attaches assets automatically, no manual dispatch needed