### PR TITLE
fix: let release-please manage Cargo.lock's version entry

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,11 @@
       "type": "json",
       "path": "/npm/package.json",
       "jsonpath": "$.version"
+    },
+    {
+      "type": "toml",
+      "path": "/Cargo.lock",
+      "jsonpath": "$.package[?(@.name==\"forgeguard\")].version"
     }
   ],
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- `v0.11.1`'s manually-dispatched `Release` run failed on every build matrix job: `cargo build --locked` errored because the tag (immutable, points at `d6aabd6`) carries a `Cargo.lock` still pinned to `forgeguard 0.11.0` while `Cargo.toml` at that same commit is already `0.11.1` — the exact drift PR #35 and #40 each fixed, just one release cycle too late for the tag itself, since Cargo.lock always gets synced in a *follow-up* PR after release-please's release commit is already tagged.
- (Side note on why `verify`'s `cargo test --locked` passed anyway: `cargo clippy`, which has no `--locked`, runs earlier in the same job and silently rewrites the lock file as a side effect. The isolated `build` matrix jobs go straight to `--locked` with no such warm-up, so they hit the raw mismatch.)

## Changes
- `release-please-config.json`: added `/Cargo.lock` as a `toml` extra-file, with a JSONPath filter (`$.package[?(@.name=="forgeguard")].version`) targeting only the `forgeguard` entry among Cargo.lock's many `[[package]]` blocks (verified locally — exactly one match). release-please's `GenericToml` updater is backed by `jsonpath-plus`, which supports this filter syntax.

This puts the Cargo.lock fix in the *same* commit release-please tags, instead of a manual follow-up PR after the fact — eliminates this class of bug for every future release, not just this one.

## Test plan
- [x] `release-please-config.json` validated as well-formed JSON
- [x] Locally parsed `Cargo.lock` and confirmed the filter targets exactly one `[[package]]` entry
- [ ] Next release-please release PR's diff includes a correct `Cargo.lock` bump
- [ ] That release's `Release` workflow run succeeds (all matrix build jobs, not just `verify`)