### PR TITLE
fix: self-heal Cargo.lock in Release instead of depending on release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@788abdaa468b02b2d53a3d1d8fcac62dc9858f4a # stable
         with:
           components: rustfmt, clippy
+      - name: Sync Cargo.lock to this release's version
+        shell: bash
+        run: |
+          version="${{ inputs.tag || github.ref_name }}"
+          cargo update -p forgeguard --precise "${version#v}"
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - run: cargo test --locked --workspace
@@ -98,6 +103,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@788abdaa468b02b2d53a3d1d8fcac62dc9858f4a # stable
         with:
           targets: ${{ matrix.target }}
+      - name: Sync Cargo.lock to this release's version
+        shell: bash
+        run: |
+          version="${{ inputs.tag || github.ref_name }}"
+          cargo update -p forgeguard --precise "${version#v}"
       - run: cargo build --locked --release --target ${{ matrix.target }}
       - name: Package Unix binary
         if: matrix.archive == 'tar'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,11 +12,6 @@
       "type": "json",
       "path": "/npm/package.json",
       "jsonpath": "$.version"
-    },
-    {
-      "type": "toml",
-      "path": "/Cargo.lock",
-      "jsonpath": "$.package[?(@.name==\"forgeguard\")].version"
     }
   ],
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- PR #41's `/Cargo.lock` extra-file (JSONPath-filtered TOML update) doesn't actually work: PR #43's latest release-please run logged `⚠ No entries modified in $.package[?(@.name=="forgeguard")].version`, despite that exact filter matching cleanly against a plain TOML parse locally. Their internal TOML handling isn't behaving the way I assumed from reading the updater source — reverting that config since a non-functional silent no-op is worse than not having it.
- Root problem stands: any tag release-please creates is immutable, and Cargo.lock never gets synced *in* that same commit. Chasing "make release-please produce a correct commit" has failed twice now (#35 pattern repeating, #41 not working). Flipping the fix to the consumer (Release itself) instead of the producer (release-please) removes the dependency entirely.

## Changes
- `.github/workflows/release.yml`: both `verify` and each `build` matrix job now run `cargo update -p forgeguard --precise <tag-version>` right after the toolchain is installed, before anything `--locked`. This touches only the `forgeguard` workspace member's own lock entry — verified locally, not guessed.
- `release-please-config.json`: reverted the non-functional `/Cargo.lock` extra-file from #41.

## Verified locally before pushing (per your ask not to keep guessing)
1. Bumped `crates/forgeguard-cli/Cargo.toml` to `0.11.2` without touching `Cargo.lock` — reproduced the exact CI failure (`cargo build --locked` → "cannot update the lock file").
2. Ran `cargo update -p forgeguard --precise 0.11.2` — diff showed **exactly one line changed** (`forgeguard`'s version), cargo itself reported "9 unchanged dependencies".
3. Re-ran `cargo build --locked --release -p forgeguard` — succeeded.
4. Ran the same `--precise` command with the version *already* current — no-op, exit 0, no diff (safe to always run unconditionally).
5. Reverted the local test changes before committing anything.

## Sequencing
This needs to merge **before** PR #43 (`chore(main): release 0.11.2`) merges, so the chained `Release` job picks up the self-heal step from `main`'s latest `release.yml` when it runs. PR #43's tagged commit will still carry a stale Cargo.lock either way (unavoidable, same as #41 not fixing that at the source) — this fix means that no longer matters.

## Test plan
- [x] Reproduced the failure and verified the fix locally, described above
- [x] Both changed files validated as well-formed YAML/JSON
- [ ] After merging this + PR #43, confirm `Release`'s build matrix jobs all succeed (not just `verify`) and all assets upload
- [ ] Confirm `npm-publish` fires and `@suiflex/forgeguard@0.11.2` publishes