### PR TITLE
fix: chain npm-publish into release-please instead of workflow_run

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,13 +4,19 @@ on:
   workflow_run:
     workflows: ["Release"]
     types: [completed]
+  workflow_call:
+    inputs:
+      tag:
+        description: Git tag that was released (e.g. v0.11.2)
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   publish:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_call' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -18,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ inputs.tag || github.event.workflow_run.head_sha }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
@@ -26,8 +32,9 @@ jobs:
       - name: Verify release tag matches package version
         shell: bash
         run: |
+          tag="${{ inputs.tag || github.event.workflow_run.head_branch }}"
           package_version="$(node -p "require('./npm/package.json').version")"
-          test "${{ github.event.workflow_run.head_branch }}" = "v$package_version"
+          test "$tag" = "v$package_version"
       # Trusted Publishing (OIDC): no NPM_TOKEN needed. Requires npm >= 11.5.1
       # and this exact workflow path registered as a Trusted Publisher on
       # npmjs.com for @suiflex/forgeguard.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,13 +10,19 @@ on:
         description: Git tag that was released (e.g. v0.11.2)
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish to npm (e.g. v0.11.2)
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   publish:
-    if: github.event_name == 'workflow_call' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,3 +46,13 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+
+  npm-publish:
+    needs: [release-please, release]
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- `v0.11.2`'s `Release` run succeeded completely — verified via `gh run view`: `release-please` job ok, `release / verify` ok, all 6 `release / Build *` matrix jobs ok, `release / publish` ok, all 12 assets on `gh release view v0.11.2`. But `npm-publish` never fired.
- Root cause: `npm-publish.yml`'s only trigger was `workflow_run: workflows: ["Release"]`. Since PR #40, `release.yml` runs as a `workflow_call` job *inside* the `release-please` run rather than producing its own standalone `Release`-named run — so that `workflow_run` match never happens via the chained path. It would only fire for a manually-dispatched standalone `Release` run (like the `v0.11.1` backfill).

## Changes
- `.github/workflows/npm-publish.yml`: added `workflow_call` (with a `tag` input) for the release-please chain, and `workflow_dispatch` (same input) to manually backfill an already-built release like `v0.11.2` without cutting a new one just to exercise the trigger. Kept the existing `workflow_run` trigger too, as a fallback for manual standalone `Release` dispatches. Checkout ref and the tag-verify step resolve from `inputs.tag` first, falling back to the `workflow_run` event fields.
- `.github/workflows/release-please.yml`: added `npm-publish` as a third job, `needs: [release-please, release]`, gated the same way as `release`, calling `npm-publish.yml` via `uses:`.

## Alternative considered
`suiflex/rdb` solves the same underlying problem (`GITHUB_TOKEN`-created tags don't cascade to other workflows) with a PAT (`secrets.RELEASE_PLEASE_TOKEN`) instead, letting `release-build.yml` stay on a plain `push: tags: v*` trigger — simpler, fewer moving parts, proven elsewhere. Decided against switching for this repo: ForgeGuard already committed to OIDC-only npm publishing with no long-lived secrets, and introducing a PAT here would cut against that.

## After merging
Manually dispatch `npm-publish` with `tag: v0.11.2` to publish the release that already has real assets but never got an npm-publish attempt.

## Test plan
- [x] All changed workflow files validated as well-formed YAML
- [x] Confirmed `v0.11.2`'s `Release` run and all its assets succeeded via `gh run view` / `gh release view`, isolating this as strictly an `npm-publish` trigger gap
- [ ] Manual `workflow_dispatch` of `npm-publish` for `v0.11.2` succeeds, `@suiflex/forgeguard@0.11.2` appears on the npm registry
- [ ] Next release-please-driven release: confirm `npm-publish` runs automatically as part of the same chain