### PR TITLE
fix: sync Cargo.lock and self-heal it in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@788abdaa468b02b2d53a3d1d8fcac62dc9858f4a # 1.78.0
+      - name: Sync Cargo.lock to Cargo.toml
+        run: cargo update -p forgeguard
       - run: cargo check --locked --workspace
 
   quality:
@@ -24,6 +26,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Sync Cargo.lock to Cargo.toml
+        run: cargo update -p forgeguard
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - run: cargo test --locked --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Summary
- PR #45's `msrv` check failed the same way v0.11.1's `Release` build did: `cargo check --locked` refused because `Cargo.lock` was still pinned to `forgeguard 0.11.1` while `Cargo.toml` on main is already `0.11.2` (from PR #43 merging). Same drift class as #35, #40, #44 — this time hitting `ci.yml` (runs on every push/PR to main) instead of `release.yml`.
- Unlike `release.yml`, `ci.yml` has no self-heal yet, so this will keep breaking the very first push/PR after every future release-please merge, indefinitely.

## Changes
- `Cargo.lock`: synced `forgeguard`'s entry to `0.11.2`. Verified locally: `cargo build --workspace` and `cargo check --locked --workspace` both clean afterward.
- `.github/workflows/ci.yml`: added `cargo update -p forgeguard` (same self-heal approach as #44) to both `msrv` and `quality`, explicitly — `quality` happened to survive so far only because `cargo clippy` (no `--locked`) runs before its `--locked` steps and silently regenerates the lock file as a side effect; making it explicit removes the reliance on that incidental ordering.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo check --locked --workspace` clean
- [x] `.github/workflows/ci.yml` validated as well-formed YAML
- [x] This PR's own `msrv`/`quality` checks pass