### PR TITLE
chore: fix CODEOWNERS and publish releases to homebrew and scoop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,10 @@
 # Default owner for everything in this repo.
 # See https://docs.github.com/articles/about-code-owners
-* @suiflex
+#
+# The owner must be a team that exists in the suiflex org and has write access to this
+# repository. GitHub does not report an unresolvable owner: it silently requests no
+# review, so a broken file looks exactly like a working one. Check with:
+#
+#   gh api repos/suiflex/ForgeGuard/codeowners/errors
+
+* @suiflex/maintener

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,9 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ github.token }}
+          # A PAT rather than github.token: pull requests opened with GITHUB_TOKEN do not
+          # trigger workflow events, so CI never ran on the release pull request itself.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,6 +44,9 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/release.yml
+    # The tap and bucket jobs need TAP_PUBLISH_TOKEN; a called workflow gets no secrets
+    # unless the caller passes them.
+    secrets: inherit
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,3 +153,94 @@ jobs:
           tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: dist/*
+
+  # Distribution channels: siblings of each other, both gated on `publish`. Neither needs
+  # the other, so a tap failure does not cancel the bucket push or vice versa.
+  #
+  # Checksums come from this run's artifacts rather than from `gh release download`: they
+  # are already built and hashed here, so there is nothing to re-fetch and no race against
+  # release-asset propagation. The build jobs write the bare hex digest with no file name,
+  # so the value is read directly.
+
+  publish-homebrew:
+    needs: publish
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Render the formula and push it to the tap
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          sha() { tr -d '[:space:]' < "dist/forgeguard-$1.tar.gz.sha256"; }
+
+          sed -e "s|@VERSION@|${version}|g" \
+              -e "s|@BASE@|${base}|g" \
+              -e "s|@MAC_ARM_SHA@|$(sha macos-aarch64)|g" \
+              -e "s|@MAC_X64_SHA@|$(sha macos-x86_64)|g" \
+              -e "s|@LINUX_ARM_SHA@|$(sha linux-aarch64)|g" \
+              -e "s|@LINUX_X64_SHA@|$(sha linux-x86_64)|g" \
+              packaging/forgeguard.rb.tmpl > forgeguard.rb
+          # A surviving placeholder means an artifact was missing. Fail here rather than
+          # publishing a formula that cannot install.
+          ! grep -q '@[A-Z_]*@' forgeguard.rb
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/suiflex/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          mv forgeguard.rb tap/Formula/forgeguard.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/forgeguard.rb
+          git commit -m "forgeguard ${version}" || { echo "tap already up to date"; exit 0; }
+          git push
+
+  publish-scoop:
+    needs: publish
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Render the manifest and push it to the bucket
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          sha() { tr -d '[:space:]' < "dist/forgeguard-$1.zip.sha256"; }
+
+          sed -e "s|@VERSION@|${version}|g" \
+              -e "s|@BASE@|${base}|g" \
+              -e "s|@WIN_X64_SHA@|$(sha windows-x86_64)|g" \
+              -e "s|@WIN_ARM64_SHA@|$(sha windows-aarch64)|g" \
+              packaging/forgeguard.json.tmpl > forgeguard.json
+          ! grep -q '@[A-Z_]*@' forgeguard.json
+          jq empty forgeguard.json
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/suiflex/scoop-bucket.git" bucket
+          mkdir -p bucket/bucket
+          mv forgeguard.json bucket/bucket/forgeguard.json
+          cd bucket
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/forgeguard.json
+          git commit -m "forgeguard ${version}" || { echo "bucket already up to date"; exit 0; }
+          git push

--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ Installers use GitHub Release binaries produced for Linux, macOS, and Windows on
 cargo install --path crates/forgeguard-cli
 ```
 
+### Homebrew
+
+```bash
+brew install suiflex/tap/forgeguard
+```
+
+A formula-installed binary is upgraded with `brew upgrade forgeguard`, not by re-running the installer. Global rules, skills, and hooks are not installed by the formula, so run `forgeguard init` afterwards.
+
+### Scoop
+
+```powershell
+scoop bucket add suiflex https://github.com/suiflex/scoop-bucket
+scoop install forgeguard
+```
+
+Upgrade with `scoop update forgeguard`.
+
 ### npm
 
 The npm package installs the matching ForgeGuard GitHub Release binary for the current OS and CPU. It requires Node.js 18 or newer:

--- a/packaging/forgeguard.json.tmpl
+++ b/packaging/forgeguard.json.tmpl
@@ -1,0 +1,28 @@
+{
+  "version": "@VERSION@",
+  "description": "Token-efficient, language-agnostic engineering guardrails for AI coding agents",
+  "homepage": "https://github.com/suiflex/ForgeGuard",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "@BASE@/forgeguard-windows-x86_64.zip",
+      "hash": "@WIN_X64_SHA@"
+    },
+    "arm64": {
+      "url": "@BASE@/forgeguard-windows-aarch64.zip",
+      "hash": "@WIN_ARM64_SHA@"
+    }
+  },
+  "bin": "forgeguard.exe",
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/suiflex/ForgeGuard/releases/download/v$version/forgeguard-windows-x86_64.zip"
+      },
+      "arm64": {
+        "url": "https://github.com/suiflex/ForgeGuard/releases/download/v$version/forgeguard-windows-aarch64.zip"
+      }
+    }
+  }
+}

--- a/packaging/forgeguard.rb.tmpl
+++ b/packaging/forgeguard.rb.tmpl
@@ -1,0 +1,43 @@
+# Template for suiflex/homebrew-tap Formula/forgeguard.rb.
+#
+# .github/workflows/release.yml renders this with sed on every tagged release, filling the
+# placeholders below from that run's build artifacts. Edit this template, never the
+# generated file in the tap: the next release overwrites it.
+#
+# The class name follows the file name, so Formula/forgeguard.rb must declare Forgeguard.
+class Forgeguard < Formula
+  desc "Token-efficient, language-agnostic engineering guardrails for AI coding agents"
+  homepage "https://github.com/suiflex/ForgeGuard"
+  version "@VERSION@"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "@BASE@/forgeguard-macos-aarch64.tar.gz"
+      sha256 "@MAC_ARM_SHA@"
+    end
+    on_intel do
+      url "@BASE@/forgeguard-macos-x86_64.tar.gz"
+      sha256 "@MAC_X64_SHA@"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "@BASE@/forgeguard-linux-aarch64.tar.gz"
+      sha256 "@LINUX_ARM_SHA@"
+    end
+    on_intel do
+      url "@BASE@/forgeguard-linux-x86_64.tar.gz"
+      sha256 "@LINUX_X64_SHA@"
+    end
+  end
+
+  def install
+    bin.install "forgeguard"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/forgeguard --version")
+  end
+end


### PR DESCRIPTION
## Summary

- `.github/CODEOWNERS` named `@suiflex`, the organization rather than a team. GitHub cannot resolve an org as a code owner and reports nothing when an owner is unresolvable — it requests no review at all, so the repository looked protected while every pull request merged unreviewed.
- ForgeGuard was absent from `suiflex/homebrew-tap` and `suiflex/scoop-bucket` even though both already exist and already serve sibling projects. macOS and Windows users had no package-manager path: only the shell installers, npm, or a source build.
- `RELEASE_PLEASE_TOKEN` was configured but unused. Pull requests opened with `GITHUB_TOKEN` do not trigger workflow events, so CI never ran on the release pull request itself.

## Changes

**CODEOWNERS**
- Default owner is now `@suiflex/maintener`. The slug is spelled that way in the org and sibling repositories already use it verbatim, so it is kept rather than corrected here. The header records the failure mode and the `gh api repos/suiflex/ForgeGuard/codeowners/errors` check.

**Packaging templates (`packaging/`)**
- `forgeguard.rb.tmpl` — Homebrew formula covering macOS and Linux on both architectures. The class is `Forgeguard` because the class name follows the file name.
- `forgeguard.json.tmpl` — Scoop manifest covering `64bit` and `arm64`, since the release already builds both Windows archives.
- Both hold only what is stable across releases; the version and per-artifact checksums are filled in at release time, so the generated files in the tap and the bucket are never hand-edited.

**`.github/workflows/release.yml`**
- New `publish-homebrew` and `publish-scoop` jobs, both gated on `publish` and siblings of each other, so a tap outage cannot block the bucket push.
- Checksums are read from this run's artifacts rather than re-fetched, which removes any wait on release-asset propagation.
- Both jobs refuse to publish a file that still holds a placeholder, and both are re-runnable: an unchanged file exits without a commit.

**`.github/workflows/release-please.yml`**
- `secrets: inherit` on the `release` job. A called workflow receives no secrets by default, so without it `TAP_PUBLISH_TOKEN` would be empty on every automated release.
- release-please now runs with `RELEASE_PLEASE_TOKEN` instead of `github.token`.

**`README.md`**
- Homebrew and Scoop install sections, each pointing at its own upgrade command — the existing upgrade section assumes the installer wrote the binary.

## Test plan

- [x] Rendered both templates against a stub `dist/` using the exact sed and checksum logic from the workflow: no placeholder survives, `ruby -c` reports Syntax OK, `jq empty` accepts the manifest, and every URL and hash lands in the right slot.
- [x] Both workflow files parse as YAML; `release.yml` exposes `verify`, `build`, `publish`, `publish-homebrew`, `publish-scoop`.
- [x] Checksum reading handles both artifact shapes — the Unix jobs write a trailing newline, the PowerShell job writes none.
- [ ] After merge: `gh api repos/suiflex/ForgeGuard/codeowners/errors` returns `{"errors":[]}`.
- [ ] After the next tagged release: `Formula/forgeguard.rb` and `bucket/forgeguard.json` appear in their repositories.
- [ ] After the next tagged release: `brew install suiflex/tap/forgeguard && forgeguard --version`, plus one `brew audit --strict suiflex/tap/forgeguard`.

## Needs confirming before the next release

- `TAP_PUBLISH_TOKEN` must carry `contents: write` on both `suiflex/homebrew-tap` and `suiflex/scoop-bucket`. The secret exists; its scope is not readable through the API.
- `@suiflex/maintener` must have write access to this repository. The `codeowners/errors` check above is the verification.
