### PR TITLE
feat(init): install only for detected agents, ask before overwriting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: cargo build --locked --workspace --release
       - run: sh -n install.sh
       - run: sh tests/install_test.sh
+      - name: Interactive init wizard (PTY)
+        run: sh tests/wizard_test.sh
       - name: Parse PowerShell installer
         shell: pwsh
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 /.forgeguard/
 /npm/vendor/
 /npm/*.tgz
+# Throwaway repositories for trying `forgeguard init` by hand. Built by
+# `sh tests/sandbox.sh`; safe to delete at any time.
+/sandbox/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,40 @@
 # ForgeGuard
 
 For code changes, use `/forgeguard-engineering`.
+
+## Working in this repository
+
+- Do not run `forgeguard init` against the repository root. ForgeGuard installs
+  into its own checkout like any other project, writing `.claude/settings.json`,
+  `.claude/skills/`, and `.forgeguard/`. Use `sh tests/sandbox.sh` to build
+  throwaway repositories under the gitignored `sandbox/` instead.
+- `AGENTS.md` is a symlink to `CLAUDE.md`; edit `CLAUDE.md`.
+
+## Checks
+
+`.github/workflows/ci.yml` runs, in order:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --locked --workspace
+cargo build --locked --workspace --release
+sh tests/install_test.sh
+sh tests/wizard_test.sh
+```
+
+`tests/wizard_test.sh` drives the interactive `init` wizard through a
+pseudo-terminal, so it needs a built binary and takes the first of
+`target/debug` or `target/release`. `sh tests/logo.sh --check` verifies the
+banner grid still matches `assets/brand/logo-mark.svg`; it is not part of CI
+because it needs macOS `qlmanage` and Pillow.
+
+## Things that have bitten before
+
+- The Windows release job only builds, so test code that fails to compile there
+  is never caught by CI. Gate unix-only tests with `#[cfg(unix)]`.
+- A `// forgeguard: allow FG-XXX -- reason` marker suppresses the rule for only
+  the two lines that follow it, so keep the marker on the line above the finding.
+- Terminal output uses the stdlib-only `theme` module in
+  `crates/forgeguard-cli/src/main.rs` — no color crates. Anything it prints must
+  collapse to plain text when stdout is not a terminal or `NO_COLOR` is set.

--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ Restart the terminal after installation. Then initialize any repository:
 
 ```bash
 cd your-project
-forgeguard init --agent all
+forgeguard init
 forgeguard doctor
 ```
+
+`forgeguard init` installs only for the agents that directory already uses. See
+[Choosing agents](#choosing-agents) for how the selection is made.
 
 Installers use GitHub Release binaries produced for Linux, macOS, and Windows on x86-64 and ARM64. Advanced users building unreleased source can still use:
 
@@ -197,12 +200,16 @@ bundle into a repository that was set up by an older version:
 
 ```bash
 cd your-project
-forgeguard init --agent all --force
+forgeguard init --force
 forgeguard doctor
 ```
 
 `--force` overwrites the ForgeGuard-owned policy and skill files and prunes obsolete
-role-skill directories.
+role-skill directories. For global installs it also relocates the Antigravity skill from
+the superseded `~/.gemini/config/skills/` to `~/.gemini/antigravity-cli/skills/`, the path
+[Antigravity CLI documents](https://antigravity.google/docs/cli/gcli-migration). ForgeGuard
+no longer writes a user-level Antigravity hook file, because none is documented; the
+workspace `.agents/hooks.json` gate is unchanged.
 
 > **Warning:** `--force` also regenerates `.forgeguard/config.toml` from detection defaults,
 > resetting any custom commands and operating mode. If you customized the config, back it up
@@ -217,7 +224,7 @@ forgeguard init --global --agent all
 
 cd your-project
 forgeguard detect
-forgeguard init --agent all
+forgeguard init
 forgeguard doctor
 forgeguard gate
 ```
@@ -265,42 +272,82 @@ forgeguard baseline create --force
 
 ## Generated project structure
 
+Only the selected agents are written. A repository that uses Claude Code alone gets:
+
 ```text
 your-project/
 ├── .forgeguard/config.toml
 ├── .forgeguard/baseline.json  # after `forgeguard baseline create`
 ├── .forgeguard/.gitignore
-├── AGENTS.md
 ├── CLAUDE.md
-├── .codex/hooks.json
 ├── .claude/settings.json
-├── .cursor/hooks.json
-├── .cursor/rules/forgeguard.mdc
-├── .agents/hooks.json
-├── .agents/rules/forgeguard.md
-├── .agents/skills/forgeguard-engineering/
-│   ├── SKILL.md
-│   └── references/
 └── .claude/skills/forgeguard-engineering/
     ├── SKILL.md
     └── references/
 ```
 
+Adding a target adds only its own files: `--agent codex` contributes `AGENTS.md`,
+`.codex/hooks.json`, and `.agents/skills/`; `--agent cursor` contributes
+`.cursor/rules/forgeguard.mdc`, `.cursor/hooks.json`, and `.agents/skills/`;
+`--agent antigravity` contributes `.agents/rules/forgeguard.md` and `.agents/hooks.json`.
+
 Existing policy and skill files are not overwritten unless `--force` is supplied. Hook installation merges one ForgeGuard entry into existing JSON and preserves unrelated settings. Global installation writes ForgeGuard-owned skills, compact policies, and hook entries for selected agents. `--force` also removes obsolete ForgeGuard-owned role-skill directories without touching unrelated skills.
 
 When a project `.gitignore` already exists, `forgeguard init` appends the generated directories for
 the selected agents (`.codex/`, `.claude/`, `.cursor/`, and/or `.agents/`). It preserves existing
-patterns, avoids duplicate entries, and does not create a root `.gitignore`.
+patterns, avoids duplicate entries, and does not create a root `.gitignore`. The `AGENTS.md`-only
+targets add no directory, so they add no ignore entry.
+
+## Choosing agents
+
+`forgeguard init` decides which integrations to write in one of three ways:
+
+1. **Explicit `--agent`** always wins and is never second-guessed. It accepts a
+   comma-separated list or a repeated flag, plus the `all` shortcut:
+
+   ```bash
+   forgeguard init --agent claude
+   forgeguard init --agent claude,codex
+   forgeguard init --agent all
+   ```
+
+2. **A terminal with no `--agent`** opens the interactive picker, with the agents
+   already configured in the directory pre-checked. Confirming an empty selection
+   installs nothing rather than everything.
+
+3. **No terminal and no `--agent`** — a script, CI job, or another agent shelling out —
+   installs only for the agents whose own configuration is already present
+   (`.claude/`, `.codex/`, `.cursor/`, `.agents/`, `.windsurf/`, `.clinerules/`,
+   `.roo/`, `.github/copilot-instructions.md`, and their user-directory equivalents
+   under `--global`).
+
+   When nothing is detected, `init` writes nothing and exits **3** with the available
+   choices on stderr, so a caller re-runs with an explicit selection instead of
+   receiving every integration at once. With `--json`, it prints
+   `{"needs_agent_selection": true, "choices": [...]}` instead. Exit code `2` still
+   means a blocked gate.
+
+Both report formats include the resolved `agents` list, so the output always states
+what was installed.
 
 ## Agent support
 
-| Agent | Rules | Skill | Automatic completion gate |
-|---|---|---|---|
-| Codex | `AGENTS.md` | `.agents/skills` | `Stop` hook |
-| Claude Code | `CLAUDE.md` | `.claude/skills` | `Stop` hook |
-| Cursor | `.cursor/rules` | `.agents/skills` | `stop` hook |
-| Antigravity | `.agents/rules` | `.agents/skills` | Native `Stop` hook |
-| OpenCode | `AGENTS.md` | `.agents/skills` | Policy-enforced gate |
+| Agent | `--agent` | Rules | Skill | Automatic completion gate |
+|---|---|---|---|---|
+| Codex | `codex` | `AGENTS.md` | `.agents/skills` | `Stop` hook |
+| Claude Code | `claude` | `CLAUDE.md` | `.claude/skills` | `Stop` hook |
+| Cursor | `cursor` | `.cursor/rules` | `.agents/skills` | `stop` hook |
+| Antigravity | `antigravity` | `.agents/rules` | `.agents/skills` | Native `Stop` hook |
+| OpenCode | `opencode` | `AGENTS.md` | `.agents/skills` | Policy-enforced gate |
+| Windsurf / Devin | `windsurf` | `AGENTS.md` | — | Policy-enforced gate |
+| GitHub Copilot | `copilot` | `AGENTS.md` | — | Policy-enforced gate |
+| Cline | `cline` | `AGENTS.md` | — | Policy-enforced gate |
+| Roo Code | `roo` | `AGENTS.md` | — | Policy-enforced gate |
+
+The last four read [`AGENTS.md`](https://agents.md/) natively, so ForgeGuard supports them
+with that one file and writes nothing under `.windsurf/`, `.github/`, `.clinerules/`, or
+`.roo/`. None of them exposes a hook API ForgeGuard can drive, and none has a documented
+skill directory, so they receive the policy but not the engineering skill.
 
 [OpenCode officially discovers](https://opencode.ai/docs/skills) both `AGENTS.md` and `.agents/skills`. Its current plugin lifecycle exposes `session.idle` only after the agent loop stops, so ForgeGuard does not claim a reliable blocking `Stop` hook there. The compact policy requires `forgeguard gate --changed --output compact` before completion. [Antigravity provides a native blocking `Stop` protocol](https://antigravity.google/docs/hooks), so failures automatically return the agent to its execution loop.
 
@@ -410,7 +457,7 @@ When run in a terminal without an explicit mode, `forgeguard mode` opens the sam
 
 | Command | Purpose |
 |---|---|
-| `forgeguard init` | Install project configuration and agent skills. Use `--global` for user-level skills. |
+| `forgeguard init` | Install project configuration and agent skills for the detected agents. Use `--agent` to select explicitly, `--global` for user-level skills. |
 | `forgeguard detect` | Detect languages, frameworks, database tools, tests, and commands. |
 | `forgeguard capabilities` | Show workflow, parser, structural-rule, and semantic-pack coverage. |
 | `forgeguard doctor` | Verify configuration, Git, and required local tools. |

--- a/README.md
+++ b/README.md
@@ -363,6 +363,11 @@ with that one file and writes nothing under `.windsurf/`, `.github/`, `.clinerul
 `.roo/`. None of them exposes a hook API ForgeGuard can drive, and none has a documented
 skill directory, so they receive the policy but not the engineering skill.
 
+User-level rules are not shared the same way, so `--global` follows each agent's own
+documented path instead: Cline reads `~/.agents/AGENTS.md`, Windsurf/Devin reads
+`~/.codeium/windsurf/memories/global_rules.md`, and Roo reads `~/.roo/rules/`. Copilot
+instructions are repository-scoped, so a global install writes nothing for it.
+
 [OpenCode officially discovers](https://opencode.ai/docs/skills) both `AGENTS.md` and `.agents/skills`. Its current plugin lifecycle exposes `session.idle` only after the agent loop stops, so ForgeGuard does not claim a reliable blocking `Stop` hook there. The compact policy requires `forgeguard gate --changed --output compact` before completion. [Antigravity provides a native blocking `Stop` protocol](https://antigravity.google/docs/hooks), so failures automatically return the agent to its execution loop.
 
 Other agents receive the universal CLI gate immediately. Agents that understand the emerging `AGENTS.md` and Agent Skills conventions also receive ForgeGuard guidance without a dedicated adapter.

--- a/README.md
+++ b/README.md
@@ -311,15 +311,29 @@ targets add no directory, so they add no ignore entry.
    forgeguard init --agent all
    ```
 
-2. **A terminal with no `--agent`** opens the interactive picker, with the agents
-   already configured in the directory pre-checked. Confirming an empty selection
-   installs nothing rather than everything.
+2. **A terminal with no `--agent`** opens the interactive picker. It lists what each
+   target writes, pre-checks the agents already configured in the directory, and
+   treats an empty selection as "install nothing" rather than "install everything".
 
 3. **No terminal and no `--agent`** — a script, CI job, or another agent shelling out —
-   installs only for the agents whose own configuration is already present
-   (`.claude/`, `.codex/`, `.cursor/`, `.agents/`, `.windsurf/`, `.clinerules/`,
-   `.roo/`, `.github/copilot-instructions.md`, and their user-directory equivalents
-   under `--global`).
+   installs only for the agents whose own configuration is already present.
+
+   | Agent | Detected by |
+   |---|---|
+   | Codex | `.codex/` |
+   | Claude Code | `.claude/` |
+   | Cursor | `.cursor/`, `.cursorrules` |
+   | OpenCode | `.opencode/`, `opencode.json` |
+   | Antigravity | `.agents/rules/`, `.agents/hooks.json`, `.agent/rules/` |
+   | Windsurf / Devin | `.windsurf/`, `.devin/`, `.windsurfrules` |
+   | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/` |
+   | Cline | `.clinerules` |
+   | Roo Code | `.roo/`, `.roorules` |
+
+   Markers are the agent's own configuration. `.agents/skills/` is deliberately not
+   one: Codex, Cursor, and OpenCode share that directory, so treating it as an
+   Antigravity marker would make every re-run silently add a target. Under
+   `--global` the equivalent user-directory paths are used instead.
 
    When nothing is detected, `init` writes nothing and exits **3** with the available
    choices on stderr, so a caller re-runs with an explicit selection instead of

--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ forgeguard init --refresh    # replace the drifted files, no prompt
 forgeguard init --force      # replace every ForgeGuard-owned file, drifted or not
 ```
 
-Neither flag touches `.forgeguard/config.toml`.
+Neither flag touches `.forgeguard/config.toml`, and neither writes through a symlink: a
+repository that points `AGENTS.md` at `CLAUDE.md` keeps both as they are, because replacing
+the link would edit the file at the other end.
 
 ## Quick start
 
@@ -500,7 +502,7 @@ When run in a terminal without an explicit mode, `forgeguard mode` opens the sam
 
 | Command | Purpose |
 |---|---|
-| `forgeguard init` | Install project configuration and agent skills for the detected agents. Use `--agent` to select explicitly, `--global` for user-level skills. |
+| `forgeguard init` | Install project configuration and agent skills for the detected agents. Use `--agent` to select explicitly, `--global` for user-level skills, `--refresh` to replace drifted files. |
 | `forgeguard detect` | Detect languages, frameworks, database tools, tests, and commands. |
 | `forgeguard capabilities` | Show workflow, parser, structural-rule, and semantic-pack coverage. |
 | `forgeguard doctor` | Verify configuration, Git, and required local tools. |

--- a/README.md
+++ b/README.md
@@ -211,10 +211,34 @@ the superseded `~/.gemini/config/skills/` to `~/.gemini/antigravity-cli/skills/`
 no longer writes a user-level Antigravity hook file, because none is documented; the
 workspace `.agents/hooks.json` gate is unchanged.
 
-> **Warning:** `--force` also regenerates `.forgeguard/config.toml` from detection defaults,
-> resetting any custom commands and operating mode. If you customized the config, back it up
-> first, or re-apply the mode afterward with `forgeguard mode default|lite|strict`. A committed
-> `.forgeguard/baseline.json` is not touched.
+`.forgeguard/config.toml` is created once and then left alone. The operating mode and any
+command you tuned survive every later `init`, `--refresh`, and `--force`; a committed
+`.forgeguard/baseline.json` is likewise untouched.
+
+### Keeping policy and skill files current
+
+A new release can ship an updated engineering skill or policy template, but the copies in your
+repository may also carry your own edits. `init` therefore compares them and reports the
+difference instead of choosing for you:
+
+```text
+┌─ 2 ForgeGuard files differ from this version ──┐
+│ CLAUDE.md                                      │
+│ .claude/skills/forgeguard-engineering/SKILL.md │
+└────────────────────────────────────────────────┘
+◇ Replace them with the bundled versions? (y/N)
+```
+
+In a terminal it asks, listing every affected file and defaulting to **no**, so a stray Enter
+never costs you your edits. Without a terminal it prints the same list and the command to run,
+and changes nothing:
+
+```bash
+forgeguard init --refresh    # replace the drifted files, no prompt
+forgeguard init --force      # replace every ForgeGuard-owned file, drifted or not
+```
+
+Neither flag touches `.forgeguard/config.toml`.
 
 ## Quick start
 

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -1381,6 +1381,21 @@ mod tests {
     }
 
     #[test]
+    fn every_menu_entry_declares_what_it_writes() {
+        // agent_menu_rows falls back to an empty summary, so a target added to
+        // AGENT_MENU without an AGENT_SUMMARY entry would render a blank column
+        // instead of failing. Catch that here.
+        for (name, _) in super::AGENT_MENU {
+            assert!(
+                super::AGENT_SUMMARY
+                    .iter()
+                    .any(|(key, summary)| key == name && !summary.is_empty()),
+                "{name} has no menu summary"
+            );
+        }
+    }
+
+    #[test]
     fn menu_rows_round_trip_back_to_targets() {
         let rows = agent_menu_rows();
         let picked = vec![rows[1].clone(), rows[6].clone()];

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -1198,24 +1198,82 @@ mod theme {
         }
     }
 
-    /// Boxed wordmark. The icon is an outlined mini-box holding an anvil mark —
-    /// ForgeGuard forges the guardrails an agent works inside. Box-drawing
-    /// characters, not filled blocks, which render as a blob at small sizes.
+    /// The shield-and-hammer mark from `assets/brand/logo-mark.svg`, sampled to
+    /// twelve by twelve. `g` is the shield, `d` the hammer struck through it, a
+    /// space is outside the mark. Regenerate with `sh tests/logo.sh`.
+    const LOGO: [&str; 12] = [
+        "gdgggggggggg",
+        "dddggggggggg",
+        "ggddddgggggg",
+        "ggggggdggggg",
+        "gggggggdgggg",
+        "gggggggdgggg",
+        "ggggdddggggg",
+        "ggggdggggggg",
+        " ggggdddddg ",
+        "  ggggggdg  ",
+        "   gggggd   ",
+        "     gg     ",
+    ];
+    const SHIELD: &str = "\x1b[38;5;114m";
+    const SHIELD_BG: &str = "\x1b[48;5;114m";
+    const STRUCK: &str = "\x1b[38;5;234m";
+    const STRUCK_BG: &str = "\x1b[48;5;234m";
+    const DEFAULT_BG: &str = "\x1b[49m";
+
+    /// Draw the mark two pixel rows per line: `▀` paints the upper half in the
+    /// foreground and the lower half in the background, so a text cell carries
+    /// two pixels. Anything outside the mark keeps the terminal's own
+    /// background rather than punching a coloured hole in it.
+    fn logo_rows() -> Vec<String> {
+        let cell = |upper: u8, lower: u8| match (upper, lower) {
+            (b' ', b' ') => " ".to_owned(),
+            (b' ', lower) => {
+                let colour = if lower == b'g' { SHIELD } else { STRUCK };
+                format!("{colour}{DEFAULT_BG}▄{RESET}")
+            }
+            (upper, b' ') => {
+                let colour = if upper == b'g' { SHIELD } else { STRUCK };
+                format!("{colour}{DEFAULT_BG}▀{RESET}")
+            }
+            (upper, lower) => {
+                let top = if upper == b'g' { SHIELD } else { STRUCK };
+                let bottom = if lower == b'g' { SHIELD_BG } else { STRUCK_BG };
+                format!("{top}{bottom}▀{RESET}")
+            }
+        };
+        LOGO.chunks(2)
+            .map(|pair| {
+                let upper = pair[0].as_bytes();
+                let lower = pair[1].as_bytes();
+                (0..upper.len())
+                    .map(|column| cell(upper[column], lower[column]))
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// The mark beside the wordmark, split the way the logo splits it: `Forge`
+    /// plain, `Guard` in the accent. Falls back to plain text whenever colour is
+    /// off, because the mark is made of colour and would otherwise be a smear of
+    /// half-blocks.
     pub(super) fn banner() -> String {
-        let rows = ["┌───┐", "│ ⌂ │  F O R G E G U A R D", "└───┘"];
-        let width = rows
-            .iter()
-            .map(|row| row.chars().count())
-            .max()
-            .unwrap_or(0)
-            + 4;
-        let mut out = vec![format!("┌{}┐", "─".repeat(width))];
-        for row in rows {
-            let pad = width - 4 - row.chars().count();
-            out.push(format!("│  {row}{}  │", " ".repeat(pad)));
+        if !enabled() {
+            return "ForgeGuard".to_owned();
         }
-        out.push(format!("└{}┘", "─".repeat(width)));
-        paint(ACCENT, &out.join("\n"))
+        let wordmark = format!("{BOLD_FG}Forge{RESET}{ACCENT}Guard{RESET}");
+        logo_rows()
+            .into_iter()
+            .enumerate()
+            .map(|(index, row)| {
+                if index == 2 {
+                    format!("  {row}   {wordmark}")
+                } else {
+                    format!("  {row}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// A row that sits on the connector column, marker at column zero.

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -40,12 +40,15 @@ struct Cli {
 enum Commands {
     /// Install or refresh ForgeGuard for a repo or globally (--force to refresh after an upgrade).
     Init {
-        /// Overwrite ForgeGuard-owned policy and skill files with the bundled
-        /// versions and prune obsolete role-skill directories. Also regenerates
-        /// .forgeguard/config.toml from detection defaults, resetting custom
-        /// commands and mode. Use to refresh an existing install after an upgrade.
+        /// Overwrite every ForgeGuard-owned policy and skill file with the
+        /// bundled version and prune obsolete role-skill directories, whether or
+        /// not it had drifted. `.forgeguard/config.toml` is left alone.
         #[arg(long)]
         force: bool,
+        /// Replace the ForgeGuard-owned files that have drifted from the bundled
+        /// versions, without prompting. Configuration is never touched.
+        #[arg(long)]
+        refresh: bool,
         /// Install rules, skills, and hooks for supported agents under the user directory.
         #[arg(long)]
         global: bool,
@@ -317,6 +320,7 @@ fn execute() -> Result<ExitCode> {
     match cli.command {
         Commands::Init {
             force,
+            refresh,
             global,
             agent,
             json,
@@ -349,7 +353,11 @@ fn execute() -> Result<ExitCode> {
                     false,
                 )
             };
-            let options = InitOptions { force, agents };
+            let options = InitOptions {
+                force,
+                refresh,
+                agents,
+            };
             if use_global {
                 let home = home_directory()?;
                 let report = initialize_global(&home, &options)?;
@@ -368,6 +376,20 @@ fn execute() -> Result<ExitCode> {
                             theme::ACCENT,
                         )
                     );
+                    if offer_refresh(&report.files_outdated)? {
+                        let report = initialize_global(
+                            &home,
+                            &InitOptions {
+                                refresh: true,
+                                ..options.clone()
+                            },
+                        )?;
+                        render_init_result(
+                            &report.agents,
+                            &report.files_written,
+                            &report.files_skipped,
+                        );
+                    }
                     if io::stdin().is_terminal() {
                         configure_mode_interactive(&home, true)?;
                     }
@@ -390,6 +412,21 @@ fn execute() -> Result<ExitCode> {
                         done.push_str("; ignored .forgeguard/ in .gitignore");
                     }
                     println!("{}\n", theme::point(&done, theme::ACCENT));
+                    if offer_refresh(&report.files_outdated)? {
+                        let report = initialize_project(
+                            &root,
+                            &InitOptions {
+                                refresh: true,
+                                ..options.clone()
+                            },
+                        )?;
+                        render_init_result(
+                            &report.agents,
+                            &report.files_written,
+                            &report.files_skipped,
+                        );
+                        println!();
+                    }
                     print!("{}", render_detection(&report.detection));
                     if io::stdin().is_terminal() {
                         configure_mode_interactive(&root, false)?;
@@ -1303,10 +1340,13 @@ mod theme {
 
     /// Bordered panel around a block of lines.
     pub(super) fn panel(lines: &[String], title: &str, color: &str) -> String {
+        // The title sits inside the top border and needs at least one dash after
+        // it, so it claims a column more than a body line of the same length.
+        // Without that the top border runs one character past the sides.
         let width = lines
             .iter()
             .map(|line| line.chars().count())
-            .chain(std::iter::once(title.chars().count()))
+            .chain(std::iter::once(title.chars().count() + 1))
             .max()
             .unwrap_or(0)
             .max(20);
@@ -1388,6 +1428,48 @@ fn summarize_paths(paths: &[String]) -> Vec<String> {
             }
         })
         .collect()
+}
+
+/// A newer release ships newer policy and skill files, but the copies on disk
+/// may also carry edits the user made. Replacing them is therefore the user's
+/// call, not the installer's: name every file, ask, and default to keeping them
+/// so a stray Enter never costs anyone their work.
+///
+/// Returns whether the caller should reinstall with `refresh` set.
+fn offer_refresh(outdated: &[String]) -> Result<bool> {
+    if outdated.is_empty() {
+        return Ok(false);
+    }
+    let summary = format!(
+        "{} ForgeGuard file{} differ{} from this version",
+        outdated.len(),
+        if outdated.len() == 1 { "" } else { "s" },
+        if outdated.len() == 1 { "s" } else { "" },
+    );
+
+    // Without a terminal there is nobody to ask, so say what is stale and how to
+    // act on it rather than overwriting on the user's behalf.
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        println!(
+            "{}",
+            theme::panel(
+                outdated,
+                "outdated — run `forgeguard init --refresh`",
+                theme::AMBER
+            )
+        );
+        return Ok(false);
+    }
+
+    println!("{}", theme::panel(outdated, &summary, theme::AMBER));
+    inquire::Confirm::new("Replace them with the bundled versions?")
+        .with_default(false)
+        .with_help_message(
+            "your edits to these files would be lost; configuration is never touched",
+        )
+        .with_render_config(theme::render_config())
+        .prompt()
+        .context("refresh prompt cancelled")
 }
 
 fn render_init_result(agents: &[AgentTarget], written: &[String], skipped: &[String]) {

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -9,8 +9,8 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use forgeguard_core::{
     config::{ForgeGuardConfig, UpdatePolicy, CONFIG_FILE},
-    create_baseline_with_config, detect_project, evaluate_context_hook, evaluate_scope_hook,
-    evaluate_stop_hook,
+    create_baseline_with_config, detect_installed_agents, detect_project, evaluate_context_hook,
+    evaluate_scope_hook, evaluate_stop_hook,
     git::changed_files,
     initialize_global, initialize_project, mark_task_ready_with_confidence, render_context_hook,
     render_hook_decision, render_scope_warning,
@@ -49,9 +49,11 @@ enum Commands {
         /// Install rules, skills, and hooks for supported agents under the user directory.
         #[arg(long)]
         global: bool,
-        /// Agents to install for. Omit in a terminal to pick interactively.
-        #[arg(long, value_enum)]
-        agent: Option<AgentArg>,
+        /// Agents to install for, comma-separated or repeated. Omit in a terminal
+        /// to pick interactively; omit elsewhere to install only for the agents
+        /// already configured in the target directory.
+        #[arg(long, value_enum, value_delimiter = ',')]
+        agent: Vec<AgentArg>,
         #[arg(long)]
         json: bool,
     },
@@ -141,6 +143,10 @@ enum AgentArg {
     #[value(name = "opencode")]
     OpenCode,
     Antigravity,
+    Windsurf,
+    Copilot,
+    Cline,
+    Roo,
     All,
 }
 
@@ -316,14 +322,32 @@ fn execute() -> Result<ExitCode> {
             json,
         } => {
             // Interactive wizard only when nothing was specified and we own a
-            // terminal. Explicit flags, --json, or a pipe keep the old behavior
-            // (default `all`) so scripts and CI are never prompted.
+            // terminal. Explicit `--agent` always wins and is never second-guessed,
+            // so existing scripts keep working unchanged.
             let interactive =
-                agent.is_none() && !global && !json && std::io::stdout().is_terminal();
+                agent.is_empty() && !global && !json && std::io::stdout().is_terminal();
             let (use_global, agents, add_gitignore) = if interactive {
-                run_init_wizard()?
+                run_init_wizard(&root)?
+            } else if agent.is_empty() {
+                // Nothing specified and nothing to prompt: install for the agents
+                // this directory already uses rather than writing every
+                // integration into a repository that wanted one.
+                let detect_root = if global {
+                    home_directory()?
+                } else {
+                    root.clone()
+                };
+                let detected = detect_installed_agents(&detect_root, global);
+                if detected.is_empty() {
+                    return no_agent_detected(json);
+                }
+                (global, detected, false)
             } else {
-                (global, vec![agent.unwrap_or(AgentArg::All).into()], false)
+                (
+                    global,
+                    agent.into_iter().map(AgentTarget::from).collect(),
+                    false,
+                )
             };
             let options = InitOptions { force, agents };
             if use_global {
@@ -336,6 +360,7 @@ fn execute() -> Result<ExitCode> {
                         "ForgeGuard global skills installed under {}",
                         report.home.display()
                     );
+                    render_agent_selection(&report.agents);
                     render_file_changes(&report.files_written, &report.files_skipped);
                     if io::stdin().is_terminal() {
                         configure_mode_interactive(&home, true)?;
@@ -350,6 +375,7 @@ fn execute() -> Result<ExitCode> {
                     println!("{}", serde_json::to_string_pretty(&report)?);
                 } else {
                     println!("ForgeGuard initialized at {}", root.display());
+                    render_agent_selection(&report.agents);
                     render_file_changes(&report.files_written, &report.files_skipped);
                     if add_gitignore {
                         println!("  ignored .forgeguard/ in .gitignore");
@@ -882,6 +908,10 @@ impl From<AgentArg> for AgentTarget {
             AgentArg::Cursor => Self::Cursor,
             AgentArg::OpenCode => Self::OpenCode,
             AgentArg::Antigravity => Self::Antigravity,
+            AgentArg::Windsurf => Self::Windsurf,
+            AgentArg::Copilot => Self::Copilot,
+            AgentArg::Cline => Self::Cline,
+            AgentArg::Roo => Self::Roo,
             AgentArg::All => Self::All,
         }
     }
@@ -908,20 +938,24 @@ impl From<HookAgentArg> for HookAgent {
     }
 }
 
-/// The five installable agents, in menu order. `AgentArg::All` is offered
-/// separately as the `all` shortcut, so it is not part of this table.
+/// The installable agents, in menu order. `AgentArg::All` is offered separately
+/// as the `all` shortcut, so it is not part of this table.
 const AGENT_MENU: &[(&str, AgentTarget)] = &[
     ("codex", AgentTarget::Codex),
     ("claude", AgentTarget::Claude),
     ("cursor", AgentTarget::Cursor),
     ("opencode", AgentTarget::OpenCode),
     ("antigravity", AgentTarget::Antigravity),
+    ("windsurf", AgentTarget::Windsurf),
+    ("copilot", AgentTarget::Copilot),
+    ("cline", AgentTarget::Cline),
+    ("roo", AgentTarget::Roo),
 ];
 
 const SCOPE_PROJECT: &str = "This repository";
 const SCOPE_GLOBAL: &str = "Global (user directory)";
 
-fn run_init_wizard() -> Result<(bool, Vec<AgentTarget>, bool)> {
+fn run_init_wizard(root: &Path) -> Result<(bool, Vec<AgentTarget>, bool)> {
     let scope = inquire::Select::new(
         "Where do you want to install?",
         vec![SCOPE_PROJECT, SCOPE_GLOBAL],
@@ -930,12 +964,12 @@ fn run_init_wizard() -> Result<(bool, Vec<AgentTarget>, bool)> {
     .context("init wizard cancelled")?;
     let use_global = scope == SCOPE_GLOBAL;
 
-    let names: Vec<&str> = AGENT_MENU.iter().map(|(name, _)| *name).collect();
-    let picked = inquire::MultiSelect::new("Which agents?", names)
-        .with_help_message("↑↓ move, space toggle, → all, ← none, enter confirm")
-        .prompt()
-        .context("init wizard cancelled")?;
-    let agents = agents_from_names(&picked);
+    let detect_root = if use_global {
+        home_directory()?
+    } else {
+        root.to_path_buf()
+    };
+    let agents = prompt_for_agents(&detect_root, use_global)?;
 
     // The gitignore entry only makes sense for a project checkout.
     let add_gitignore = if use_global {
@@ -950,19 +984,46 @@ fn run_init_wizard() -> Result<(bool, Vec<AgentTarget>, bool)> {
     Ok((use_global, agents, add_gitignore))
 }
 
-/// Map the agent names the user checked onto concrete targets. An empty pick
-/// falls back to `All` so confirming nothing never installs nothing.
+/// Ask which agents to install for, with the ones already configured under
+/// `detect_root` pre-checked. An empty pick used to mean "install everything",
+/// which turned a stray Enter into every integration written at once; it now
+/// re-asks and then cancels, because writing nothing is always recoverable.
+fn prompt_for_agents(detect_root: &Path, global: bool) -> Result<Vec<AgentTarget>> {
+    let names: Vec<&str> = AGENT_MENU.iter().map(|(name, _)| *name).collect();
+    let detected = detect_installed_agents(detect_root, global);
+    let defaults: Vec<usize> = AGENT_MENU
+        .iter()
+        .enumerate()
+        .filter(|(_, (_, target))| detected.contains(target))
+        .map(|(index, _)| index)
+        .collect();
+
+    let help = "↑↓ move, space toggle, → all, ← none, enter confirm";
+    for attempt in 0..2 {
+        let picked = inquire::MultiSelect::new("Which agents?", names.clone())
+            .with_default(&defaults)
+            .with_help_message(if attempt == 0 {
+                help
+            } else {
+                "nothing selected — pick at least one, or press Esc to cancel"
+            })
+            .prompt()
+            .context("init wizard cancelled")?;
+        let agents = agents_from_names(&picked);
+        if !agents.is_empty() {
+            return Ok(agents);
+        }
+    }
+    bail!("no agent selected; nothing was installed")
+}
+
+/// Map the agent names the user checked onto concrete targets, in menu order.
 fn agents_from_names(names: &[&str]) -> Vec<AgentTarget> {
-    let selected: Vec<AgentTarget> = AGENT_MENU
+    AGENT_MENU
         .iter()
         .filter(|(name, _)| names.contains(name))
         .map(|(_, target)| *target)
-        .collect();
-    if selected.is_empty() {
-        vec![AgentTarget::All]
-    } else {
-        selected
-    }
+        .collect()
 }
 
 fn home_directory() -> Result<PathBuf> {
@@ -970,6 +1031,50 @@ fn home_directory() -> Result<PathBuf> {
         .or_else(|| env::var_os("USERPROFILE"))
         .map(PathBuf::from)
         .context("could not determine the user home directory")
+}
+
+/// Exit code for "I will not guess": no `--agent`, no terminal to ask in, and no
+/// configured agent to infer from. Distinct from `2`, which a blocked gate uses.
+const EXIT_NEEDS_AGENT_SELECTION: u8 = 3;
+
+/// Refuse to install rather than pick every agent by default. A caller that is a
+/// script or another agent reads this and re-runs with an explicit selection.
+fn no_agent_detected(json: bool) -> Result<ExitCode> {
+    let choices: Vec<&str> = AGENT_MENU
+        .iter()
+        .map(|(name, _)| *name)
+        .chain(["all"])
+        .collect();
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "needs_agent_selection": true,
+                "choices": choices,
+            }))?
+        );
+    } else {
+        eprintln!(
+            "no agent configuration detected; nothing was installed.\n\
+             Re-run with an explicit selection, for example:\n  \
+             forgeguard init --agent claude\n  \
+             forgeguard init --agent claude,codex\n\
+             Available: {}",
+            choices.join(", ")
+        );
+    }
+    Ok(ExitCode::from(EXIT_NEEDS_AGENT_SELECTION))
+}
+
+fn render_agent_selection(agents: &[AgentTarget]) {
+    let names: Vec<&str> = AGENT_MENU
+        .iter()
+        .filter(|(_, target)| agents.contains(target))
+        .map(|(name, _)| *name)
+        .collect();
+    if !names.is_empty() {
+        println!("  agents: {}", names.join(", "));
+    }
 }
 
 fn render_file_changes(written: &[String], skipped: &[String]) {
@@ -998,8 +1103,8 @@ mod tests {
     }
 
     #[test]
-    fn empty_pick_defaults_to_all() {
-        assert_eq!(agents_from_names(&[]), vec![AgentTarget::All]);
+    fn empty_pick_installs_nothing() {
+        assert!(agents_from_names(&[]).is_empty());
     }
 
     #[test]

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -356,12 +356,18 @@ fn execute() -> Result<ExitCode> {
                 if json {
                     println!("{}", serde_json::to_string_pretty(&report)?);
                 } else {
-                    println!(
-                        "ForgeGuard global skills installed under {}",
-                        report.home.display()
+                    render_init_result(
+                        &report.agents,
+                        &report.files_written,
+                        &report.files_skipped,
                     );
-                    render_agent_selection(&report.agents);
-                    render_file_changes(&report.files_written, &report.files_skipped);
+                    println!(
+                        "{}",
+                        theme::point(
+                            &format!("global install under {}", report.home.display()),
+                            theme::ACCENT,
+                        )
+                    );
                     if io::stdin().is_terminal() {
                         configure_mode_interactive(&home, true)?;
                     }
@@ -374,13 +380,16 @@ fn execute() -> Result<ExitCode> {
                 if json {
                     println!("{}", serde_json::to_string_pretty(&report)?);
                 } else {
-                    println!("ForgeGuard initialized at {}", root.display());
-                    render_agent_selection(&report.agents);
-                    render_file_changes(&report.files_written, &report.files_skipped);
+                    render_init_result(
+                        &report.agents,
+                        &report.files_written,
+                        &report.files_skipped,
+                    );
+                    let mut done = format!("initialized at {}", root.display());
                     if add_gitignore {
-                        println!("  ignored .forgeguard/ in .gitignore");
+                        done.push_str("; ignored .forgeguard/ in .gitignore");
                     }
-                    println!();
+                    println!("{}\n", theme::point(&done, theme::ACCENT));
                     print!("{}", render_detection(&report.detection));
                     if io::stdin().is_terminal() {
                         configure_mode_interactive(&root, false)?;
@@ -952,14 +961,31 @@ const AGENT_MENU: &[(&str, AgentTarget)] = &[
     ("roo", AgentTarget::Roo),
 ];
 
+/// What each menu entry actually writes, so the picker states the cost of a row
+/// instead of making the reader guess from a bare name.
+const AGENT_SUMMARY: &[(&str, &str)] = &[
+    ("codex", "AGENTS.md, shared skill, Stop hook"),
+    ("claude", "CLAUDE.md, own skill, Stop hook"),
+    ("cursor", ".cursor/rules, shared skill, stop hook"),
+    ("opencode", "AGENTS.md, shared skill"),
+    ("antigravity", ".agents/rules, shared skill, Stop hook"),
+    ("windsurf", "AGENTS.md only"),
+    ("copilot", "AGENTS.md only"),
+    ("cline", "AGENTS.md only"),
+    ("roo", "AGENTS.md only"),
+];
+
 const SCOPE_PROJECT: &str = "This repository";
 const SCOPE_GLOBAL: &str = "Global (user directory)";
 
 fn run_init_wizard(root: &Path) -> Result<(bool, Vec<AgentTarget>, bool)> {
+    println!("{}\n", theme::banner());
+
     let scope = inquire::Select::new(
         "Where do you want to install?",
         vec![SCOPE_PROJECT, SCOPE_GLOBAL],
     )
+    .with_render_config(theme::render_config())
     .prompt()
     .context("init wizard cancelled")?;
     let use_global = scope == SCOPE_GLOBAL;
@@ -969,7 +995,27 @@ fn run_init_wizard(root: &Path) -> Result<(bool, Vec<AgentTarget>, bool)> {
     } else {
         root.to_path_buf()
     };
-    let agents = prompt_for_agents(&detect_root, use_global)?;
+
+    let detected = detect_installed_agents(&detect_root, use_global);
+    let found = agent_names(&detected);
+    println!(
+        "\n{}\n",
+        theme::step(
+            "init — detected",
+            &[if found.is_empty() {
+                "no agent configuration found; nothing is pre-selected".to_owned()
+            } else {
+                format!("{} — pre-selected below", found.join(", "))
+            }],
+            if found.is_empty() {
+                theme::AMBER
+            } else {
+                theme::ACCENT
+            },
+        )
+    );
+
+    let agents = prompt_for_agents(&detected)?;
 
     // The gitignore entry only makes sense for a project checkout.
     let add_gitignore = if use_global {
@@ -977,10 +1023,12 @@ fn run_init_wizard(root: &Path) -> Result<(bool, Vec<AgentTarget>, bool)> {
     } else {
         inquire::Confirm::new("Add .forgeguard/ to .gitignore?")
             .with_default(true)
+            .with_render_config(theme::render_config())
             .prompt()
             .context("init wizard cancelled")?
     };
 
+    println!();
     Ok((use_global, agents, add_gitignore))
 }
 
@@ -988,9 +1036,8 @@ fn run_init_wizard(root: &Path) -> Result<(bool, Vec<AgentTarget>, bool)> {
 /// `detect_root` pre-checked. An empty pick used to mean "install everything",
 /// which turned a stray Enter into every integration written at once; it now
 /// re-asks and then cancels, because writing nothing is always recoverable.
-fn prompt_for_agents(detect_root: &Path, global: bool) -> Result<Vec<AgentTarget>> {
-    let names: Vec<&str> = AGENT_MENU.iter().map(|(name, _)| *name).collect();
-    let detected = detect_installed_agents(detect_root, global);
+fn prompt_for_agents(detected: &[AgentTarget]) -> Result<Vec<AgentTarget>> {
+    let rows = agent_menu_rows();
     let defaults: Vec<usize> = AGENT_MENU
         .iter()
         .enumerate()
@@ -998,10 +1045,22 @@ fn prompt_for_agents(detect_root: &Path, global: bool) -> Result<Vec<AgentTarget
         .map(|(index, _)| index)
         .collect();
 
-    let help = "↑↓ move, space toggle, → all, ← none, enter confirm";
+    let help = "↑↓ move · space toggle · → all · ← none · enter confirm";
     for attempt in 0..2 {
-        let picked = inquire::MultiSelect::new("Which agents?", names.clone())
+        // Each row carries its summary, which makes a useful menu but a wrapped
+        // mess once echoed back as the answer. Echo the names alone.
+        let formatter = &|picked: &[inquire::list_option::ListOption<&String>]| -> String {
+            picked
+                .iter()
+                .map(|option| option.value.split_whitespace().next().unwrap_or_default())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let picked = inquire::MultiSelect::new("Which agents?", rows.clone())
             .with_default(&defaults)
+            .with_page_size(AGENT_MENU.len())
+            .with_formatter(formatter)
+            .with_render_config(theme::render_config())
             .with_help_message(if attempt == 0 {
                 help
             } else {
@@ -1009,12 +1068,44 @@ fn prompt_for_agents(detect_root: &Path, global: bool) -> Result<Vec<AgentTarget
             })
             .prompt()
             .context("init wizard cancelled")?;
-        let agents = agents_from_names(&picked);
+        let agents = agents_from_rows(&picked);
         if !agents.is_empty() {
             return Ok(agents);
         }
+        println!("{}", theme::point("nothing selected", theme::AMBER));
     }
     bail!("no agent selected; nothing was installed")
+}
+
+/// Menu rows pair the target name with what selecting it writes, padded so the
+/// summaries line up into a readable column.
+fn agent_menu_rows() -> Vec<String> {
+    let width = AGENT_MENU
+        .iter()
+        .map(|(name, _)| name.len())
+        .max()
+        .unwrap_or(0);
+    AGENT_MENU
+        .iter()
+        .map(|(name, _)| {
+            let summary = AGENT_SUMMARY
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, summary)| *summary)
+                .unwrap_or_default();
+            format!("{name:<width$}  {summary}")
+        })
+        .collect()
+}
+
+/// Recover the targets behind the rows the user checked, in menu order. Rows are
+/// generated from `AGENT_MENU`, so matching on the name prefix is exact.
+fn agents_from_rows(rows: &[String]) -> Vec<AgentTarget> {
+    let names: Vec<&str> = rows
+        .iter()
+        .map(|row| row.split_whitespace().next().unwrap_or_default())
+        .collect();
+    agents_from_names(&names)
 }
 
 /// Map the agent names the user checked onto concrete targets, in menu order.
@@ -1055,35 +1146,207 @@ fn no_agent_detected(json: bool) -> Result<ExitCode> {
         );
     } else {
         eprintln!(
-            "no agent configuration detected; nothing was installed.\n\
-             Re-run with an explicit selection, for example:\n  \
-             forgeguard init --agent claude\n  \
-             forgeguard init --agent claude,codex\n\
-             Available: {}",
-            choices.join(", ")
+            "{}",
+            theme::panel(
+                &[
+                    "forgeguard init --agent claude".to_owned(),
+                    "forgeguard init --agent claude,codex".to_owned(),
+                    String::new(),
+                    format!("available: {}", choices.join(", ")),
+                ],
+                "pick an agent",
+                theme::VIOLET,
+            )
+        );
+        eprintln!(
+            "{}",
+            theme::point(
+                "no agent configuration detected; nothing was installed",
+                theme::AMBER,
+            )
         );
     }
     Ok(ExitCode::from(EXIT_NEEDS_AGENT_SELECTION))
 }
 
-fn render_agent_selection(agents: &[AgentTarget]) {
-    let names: Vec<&str> = AGENT_MENU
-        .iter()
-        .filter(|(_, target)| agents.contains(target))
-        .map(|(name, _)| *name)
-        .collect();
-    if !names.is_empty() {
-        println!("  agents: {}", names.join(", "));
+/// Terminal branding: ANSI colors, banner, and bordered panels.
+///
+/// Stdlib only — no `owo-colors`, no `console`. Colors are 256-color
+/// approximations of the shared palette so ForgeGuard, websift, and suitest read
+/// as one product, and everything collapses to plain text when stdout is not a
+/// terminal or `NO_COLOR` is set.
+mod theme {
+    use std::io::IsTerminal;
+
+    use inquire::ui::{Attributes, Color, RenderConfig, StyleSheet, Styled};
+
+    pub(super) const ACCENT: &str = "\x1b[38;5;114m"; // #4ade80
+    pub(super) const AMBER: &str = "\x1b[38;5;221m"; // #fbbf24
+    pub(super) const VIOLET: &str = "\x1b[38;5;146m"; // #a78bfa
+    const BOLD_FG: &str = "\x1b[1;38;5;255m"; // #fafafa
+    const RESET: &str = "\x1b[0m";
+
+    fn enabled() -> bool {
+        std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none()
+    }
+
+    fn paint(color: &str, text: &str) -> String {
+        if enabled() {
+            format!("{color}{text}{RESET}")
+        } else {
+            text.to_owned()
+        }
+    }
+
+    /// Boxed wordmark. The icon is an outlined mini-box holding an anvil mark —
+    /// ForgeGuard forges the guardrails an agent works inside. Box-drawing
+    /// characters, not filled blocks, which render as a blob at small sizes.
+    pub(super) fn banner() -> String {
+        let rows = ["┌───┐", "│ ⌂ │  F O R G E G U A R D", "└───┘"];
+        let width = rows
+            .iter()
+            .map(|row| row.chars().count())
+            .max()
+            .unwrap_or(0)
+            + 4;
+        let mut out = vec![format!("┌{}┐", "─".repeat(width))];
+        for row in rows {
+            let pad = width - 4 - row.chars().count();
+            out.push(format!("│  {row}{}  │", " ".repeat(pad)));
+        }
+        out.push(format!("└{}┘", "─".repeat(width)));
+        paint(ACCENT, &out.join("\n"))
+    }
+
+    /// A row that sits on the connector column, marker at column zero.
+    pub(super) fn point(text: &str, color: &str) -> String {
+        paint(color, &format!("◇ {text}"))
+    }
+
+    /// One step of the flow: a labeled rule, then body lines under a shared gutter.
+    pub(super) fn step(label: &str, lines: &[String], color: &str) -> String {
+        let rule = "─".repeat(30usize.saturating_sub(label.len()).max(3));
+        let mut out = vec![point(&format!("{label} {rule}"), color), gutter("", color)];
+        for line in lines {
+            out.push(gutter(&paint(BOLD_FG, line), color));
+        }
+        out.push(gutter("", color));
+        out.join("\n")
+    }
+
+    fn gutter(text: &str, color: &str) -> String {
+        let bar = paint(color, "│");
+        if text.is_empty() {
+            bar
+        } else {
+            format!("{bar} {text}")
+        }
+    }
+
+    /// Bordered panel around a block of lines.
+    pub(super) fn panel(lines: &[String], title: &str, color: &str) -> String {
+        let width = lines
+            .iter()
+            .map(|line| line.chars().count())
+            .chain(std::iter::once(title.chars().count()))
+            .max()
+            .unwrap_or(0)
+            .max(20);
+        let mut out = vec![paint(
+            color,
+            &format!(
+                "┌─ {title} {}┐",
+                "─".repeat((width + 2).saturating_sub(title.chars().count() + 3))
+            ),
+        )];
+        for line in lines {
+            let pad = " ".repeat(width - line.chars().count());
+            out.push(format!(
+                "{} {}{pad} {}",
+                paint(color, "│"),
+                paint(BOLD_FG, line),
+                paint(color, "│")
+            ));
+        }
+        out.push(paint(color, &format!("└{}┘", "─".repeat(width + 2))));
+        out.join("\n")
+    }
+
+    /// Bind the prompt widgets to the same accent the rest of the flow uses.
+    pub(super) fn render_config() -> RenderConfig<'static> {
+        if !enabled() {
+            return RenderConfig::empty();
+        }
+        let accent = Color::LightGreen;
+        RenderConfig::default()
+            .with_prompt_prefix(Styled::new("◇").with_fg(accent))
+            .with_answered_prompt_prefix(Styled::new("◇").with_fg(accent))
+            .with_highlighted_option_prefix(Styled::new("›").with_fg(accent))
+            .with_selected_checkbox(Styled::new("◼").with_fg(accent))
+            .with_unselected_checkbox(Styled::new("◻").with_fg(Color::DarkGrey))
+            .with_answer(StyleSheet::new().with_fg(accent))
+            .with_help_message(StyleSheet::new().with_fg(Color::DarkGrey))
+            .with_option(StyleSheet::empty())
+            .with_selected_option(Some(
+                StyleSheet::new()
+                    .with_fg(accent)
+                    .with_attr(Attributes::BOLD),
+            ))
     }
 }
 
-fn render_file_changes(written: &[String], skipped: &[String]) {
-    for path in written {
-        println!("  created {path}");
+fn agent_names(agents: &[AgentTarget]) -> Vec<&'static str> {
+    AGENT_MENU
+        .iter()
+        .filter(|(_, target)| agents.contains(target))
+        .map(|(name, _)| *name)
+        .collect()
+}
+
+/// Collapse a write list into one line per top-level directory. A single-agent
+/// install touches sixteen paths, and printing each one buries the two facts that
+/// matter: which agent, and which trees changed.
+fn summarize_paths(paths: &[String]) -> Vec<String> {
+    let mut groups: Vec<(String, usize)> = Vec::new();
+    for path in paths {
+        let key = match path.split_once('/') {
+            Some((directory, _)) => format!("{directory}/"),
+            None => path.clone(),
+        };
+        // A map would cost the insertion order the rendered output depends on.
+        // forgeguard: allow FG-ALG-002 -- groups are top-level directories, of which ForgeGuard writes at most six
+        match groups.iter_mut().find(|(name, _)| *name == key) {
+            Some((_, count)) => *count += 1,
+            None => groups.push((key, 1)),
+        }
     }
-    for path in skipped {
-        println!("  skipped {path} (already exists)");
+    groups
+        .into_iter()
+        .map(|(name, count)| {
+            if count > 1 {
+                format!("{name} ({count} files)")
+            } else {
+                name
+            }
+        })
+        .collect()
+}
+
+fn render_init_result(agents: &[AgentTarget], written: &[String], skipped: &[String]) {
+    let mut body = vec![format!("agents   {}", agent_names(agents).join(", "))];
+    for (index, line) in summarize_paths(written).into_iter().enumerate() {
+        body.push(format!(
+            "{:<8} {line}",
+            if index == 0 { "wrote" } else { "" }
+        ));
     }
+    for (index, line) in summarize_paths(skipped).into_iter().enumerate() {
+        body.push(format!(
+            "{:<8} {line}",
+            if index == 0 { "kept" } else { "" }
+        ));
+    }
+    println!("{}", theme::panel(&body, "installed", theme::ACCENT));
 }
 
 #[cfg(test)]
@@ -1091,7 +1354,8 @@ mod tests {
     use clap::Parser;
 
     use super::{
-        agents_from_names, AgentTarget, BaselineCommands, Cli, Commands, ConfigCommands, OutputArg,
+        agent_menu_rows, agents_from_names, agents_from_rows, summarize_paths, AgentTarget,
+        BaselineCommands, Cli, Commands, ConfigCommands, OutputArg,
     };
 
     #[test]
@@ -1105,6 +1369,46 @@ mod tests {
     #[test]
     fn empty_pick_installs_nothing() {
         assert!(agents_from_names(&[]).is_empty());
+    }
+
+    #[test]
+    fn menu_rows_pair_each_agent_with_what_it_writes() {
+        let rows = agent_menu_rows();
+
+        assert!(rows[1].starts_with("claude "));
+        assert!(rows[1].ends_with("CLAUDE.md, own skill, Stop hook"));
+        assert!(rows.iter().all(|row| row.contains("  ")));
+    }
+
+    #[test]
+    fn menu_rows_round_trip_back_to_targets() {
+        let rows = agent_menu_rows();
+        let picked = vec![rows[1].clone(), rows[6].clone()];
+
+        assert_eq!(
+            agents_from_rows(&picked),
+            vec![AgentTarget::Claude, AgentTarget::Copilot]
+        );
+    }
+
+    #[test]
+    fn writes_collapse_to_one_line_per_directory() {
+        let written = vec![
+            ".forgeguard/config.toml".to_owned(),
+            ".forgeguard/.gitignore".to_owned(),
+            "CLAUDE.md".to_owned(),
+            ".claude/settings.json".to_owned(),
+            ".claude/skills/forgeguard-engineering/SKILL.md".to_owned(),
+        ];
+
+        assert_eq!(
+            summarize_paths(&written),
+            vec![
+                ".forgeguard/ (2 files)".to_owned(),
+                "CLAUDE.md".to_owned(),
+                ".claude/ (2 files)".to_owned(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -319,20 +319,20 @@ fn install_agents(
     root: &Path,
     scope: InstallScope,
     requested: &[AgentTarget],
-    force: bool,
+    overwrite: bool,
     log: &mut InstallLog,
 ) -> Result<()> {
     for target in expand_agent_targets(requested) {
         match target {
-            AgentTarget::Codex => install_codex(root, scope, force, log)?,
-            AgentTarget::Claude => install_claude(root, scope, force, log)?,
-            AgentTarget::Cursor => install_cursor(root, scope, force, log)?,
-            AgentTarget::OpenCode => install_opencode(root, scope, force, log)?,
-            AgentTarget::Antigravity => install_antigravity(root, scope, force, log)?,
+            AgentTarget::Codex => install_codex(root, scope, overwrite, log)?,
+            AgentTarget::Claude => install_claude(root, scope, overwrite, log)?,
+            AgentTarget::Cursor => install_cursor(root, scope, overwrite, log)?,
+            AgentTarget::OpenCode => install_opencode(root, scope, overwrite, log)?,
+            AgentTarget::Antigravity => install_antigravity(root, scope, overwrite, log)?,
             AgentTarget::Windsurf
             | AgentTarget::Copilot
             | AgentTarget::Cline
-            | AgentTarget::Roo => install_agents_md(root, target, scope, force, log)?,
+            | AgentTarget::Roo => install_agents_md(root, target, scope, overwrite, log)?,
             AgentTarget::All => unreachable!("all is expanded before installation"),
         }
     }
@@ -436,18 +436,23 @@ fn write_config(root: &Path, config: &ForgeGuardConfig, log: &mut InstallLog) ->
 fn install_codex(
     root: &Path,
     scope: InstallScope,
-    force: bool,
+    overwrite: bool,
     log: &mut InstallLog,
 ) -> Result<()> {
-    if force {
+    if overwrite {
         remove_legacy_skills(root, ".codex/skills", true)?;
     }
     let policy_path = match scope {
         InstallScope::Project => root.join("AGENTS.md"),
         InstallScope::Global => root.join(".codex/AGENTS.md"),
     };
-    write_file(root, &policy_path, AGENTS_TEMPLATE, force, log)?;
-    install_skill(root, ".agents/skills/forgeguard-engineering", force, log)?;
+    write_file(root, &policy_path, AGENTS_TEMPLATE, overwrite, log)?;
+    install_skill(
+        root,
+        ".agents/skills/forgeguard-engineering",
+        overwrite,
+        log,
+    )?;
     install_grouped_hook(
         root,
         &root.join(".codex/hooks.json"),
@@ -477,18 +482,23 @@ fn install_codex(
 fn install_claude(
     root: &Path,
     scope: InstallScope,
-    force: bool,
+    overwrite: bool,
     log: &mut InstallLog,
 ) -> Result<()> {
-    if force {
+    if overwrite {
         remove_legacy_skills(root, ".claude/skills", false)?;
     }
     let policy_path = match scope {
         InstallScope::Project => root.join("CLAUDE.md"),
         InstallScope::Global => root.join(".claude/CLAUDE.md"),
     };
-    write_file(root, &policy_path, CLAUDE_TEMPLATE, force, log)?;
-    install_skill(root, ".claude/skills/forgeguard-engineering", force, log)?;
+    write_file(root, &policy_path, CLAUDE_TEMPLATE, overwrite, log)?;
+    install_skill(
+        root,
+        ".claude/skills/forgeguard-engineering",
+        overwrite,
+        log,
+    )?;
     install_grouped_hook(
         root,
         &root.join(".claude/settings.json"),
@@ -526,15 +536,20 @@ fn install_claude(
 fn install_cursor(
     root: &Path,
     scope: InstallScope,
-    force: bool,
+    overwrite: bool,
     log: &mut InstallLog,
 ) -> Result<()> {
     let rule_path = match scope {
         InstallScope::Project => root.join(".cursor/rules/forgeguard.mdc"),
         InstallScope::Global => root.join(".cursor/rules/forgeguard.mdc"),
     };
-    write_file(root, &rule_path, CURSOR_TEMPLATE, force, log)?;
-    install_skill(root, ".agents/skills/forgeguard-engineering", force, log)?;
+    write_file(root, &rule_path, CURSOR_TEMPLATE, overwrite, log)?;
+    install_skill(
+        root,
+        ".agents/skills/forgeguard-engineering",
+        overwrite,
+        log,
+    )?;
     let path = root.join(".cursor/hooks.json");
     install_cursor_hook(root, &path, "stop", None, CURSOR_HOOK_COMMAND, log)?;
     install_cursor_hook(
@@ -558,7 +573,7 @@ fn install_cursor(
 fn install_opencode(
     root: &Path,
     scope: InstallScope,
-    force: bool,
+    overwrite: bool,
     log: &mut InstallLog,
 ) -> Result<()> {
     let (policy_path, skill_directory) = match scope {
@@ -571,14 +586,14 @@ fn install_opencode(
             ".config/opencode/skills/forgeguard-engineering",
         ),
     };
-    write_file(root, &policy_path, AGENTS_TEMPLATE, force, log)?;
-    install_skill(root, skill_directory, force, log)
+    write_file(root, &policy_path, AGENTS_TEMPLATE, overwrite, log)?;
+    install_skill(root, skill_directory, overwrite, log)
 }
 
 fn install_antigravity(
     root: &Path,
     scope: InstallScope,
-    force: bool,
+    overwrite: bool,
     log: &mut InstallLog,
 ) -> Result<()> {
     let (policy_path, skill_directory) = match scope {
@@ -591,11 +606,11 @@ fn install_antigravity(
             GLOBAL_ANTIGRAVITY_SKILL_DIRECTORY,
         ),
     };
-    if force {
+    if overwrite {
         remove_directory(root, OBSOLETE_GLOBAL_ANTIGRAVITY_SKILL_DIRECTORY)?;
     }
-    write_file(root, &policy_path, AGENTS_TEMPLATE, force, log)?;
-    install_skill(root, skill_directory, force, log)?;
+    write_file(root, &policy_path, AGENTS_TEMPLATE, overwrite, log)?;
+    install_skill(root, skill_directory, overwrite, log)?;
 
     // Only the workspace agent has a documented local hook file. Antigravity
     // publishes no user-level hook path, so a global install stops at rules and
@@ -634,7 +649,7 @@ fn install_agents_md(
     root: &Path,
     target: AgentTarget,
     scope: InstallScope,
-    force: bool,
+    overwrite: bool,
     log: &mut InstallLog,
 ) -> Result<()> {
     let relative = match scope {
@@ -644,7 +659,7 @@ fn install_agents_md(
             None => return Ok(()),
         },
     };
-    write_file(root, &root.join(relative), AGENTS_TEMPLATE, force, log)
+    write_file(root, &root.join(relative), AGENTS_TEMPLATE, overwrite, log)
 }
 
 /// Where each `AGENTS.md`-only agent reads user-level rules from. `None` means the
@@ -663,12 +678,17 @@ fn global_policy_path(target: AgentTarget) -> Option<&'static str> {
     }
 }
 
-fn install_skill(root: &Path, directory: &str, force: bool, log: &mut InstallLog) -> Result<()> {
+fn install_skill(
+    root: &Path,
+    directory: &str,
+    overwrite: bool,
+    log: &mut InstallLog,
+) -> Result<()> {
     for (relative, content) in SKILL_ASSETS {
         let path = root.join(directory).join(relative);
-        write_file(root, &path, content, force, log)?;
+        write_file(root, &path, content, overwrite, log)?;
     }
-    if force {
+    if overwrite {
         remove_obsolete_skill_assets(root, directory)?;
     }
     Ok(())
@@ -1015,7 +1035,7 @@ fn write_file(
     root: &Path,
     path: &Path,
     content: &str,
-    force: bool,
+    overwrite: bool,
     log: &mut InstallLog,
 ) -> Result<()> {
     let relative = path
@@ -1043,7 +1063,7 @@ fn write_file(
             record(&mut log.skipped, relative);
             return Ok(());
         }
-        if !force {
+        if !overwrite {
             record(&mut log.outdated, relative.clone());
             record(&mut log.skipped, relative);
             return Ok(());

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -123,7 +123,12 @@ pub enum AgentTarget {
 
 #[derive(Debug, Clone)]
 pub struct InitOptions {
+    /// Reinstall every ForgeGuard-owned file and prune superseded directories.
     pub force: bool,
+    /// Overwrite only the ForgeGuard-owned files that have drifted from the
+    /// bundled versions. The non-interactive form of answering yes to the
+    /// refresh prompt.
+    pub refresh: bool,
     pub agents: Vec<AgentTarget>,
 }
 
@@ -131,9 +136,22 @@ impl Default for InitOptions {
     fn default() -> Self {
         Self {
             force: false,
+            refresh: false,
             agents: vec![AgentTarget::All],
         }
     }
+}
+
+/// What an install did, split so the caller can tell "already correct" from
+/// "exists but stale".
+#[derive(Debug, Default)]
+struct InstallLog {
+    written: Vec<String>,
+    skipped: Vec<String>,
+    /// ForgeGuard-owned files that exist but no longer match the bundled
+    /// version. Replacing a file the user may have edited is their decision, so
+    /// these are reported rather than silently rewritten.
+    outdated: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -143,6 +161,8 @@ pub struct InitReport {
     pub agents: Vec<AgentTarget>,
     pub files_written: Vec<String>,
     pub files_skipped: Vec<String>,
+    /// Existing ForgeGuard-owned files that differ from the bundled versions.
+    pub files_outdated: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -151,6 +171,7 @@ pub struct GlobalInitReport {
     pub agents: Vec<AgentTarget>,
     pub files_written: Vec<String>,
     pub files_skipped: Vec<String>,
+    pub files_outdated: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -234,23 +255,22 @@ pub fn initialize_global(home: &Path, options: &InitOptions) -> Result<GlobalIni
     let home = home
         .canonicalize()
         .with_context(|| format!("failed to resolve home directory {}", home.display()))?;
-    let mut files_written = Vec::new();
-    let mut files_skipped = Vec::new();
+    let mut log = InstallLog::default();
 
     install_agents(
         &home,
         InstallScope::Global,
         &options.agents,
-        options.force,
-        &mut files_written,
-        &mut files_skipped,
+        options.force || options.refresh,
+        &mut log,
     )?;
 
     Ok(GlobalInitReport {
         home,
         agents: expand_agent_targets(&options.agents),
-        files_written,
-        files_skipped,
+        files_written: log.written,
+        files_skipped: log.skipped,
+        files_outdated: log.outdated,
     })
 }
 
@@ -262,40 +282,36 @@ pub fn initialize_project(root: &Path, options: &InitOptions) -> Result<InitRepo
         .unwrap_or("project");
     let config = ForgeGuardConfig::new(project_name, detection.suggested_commands.clone());
 
-    let mut files_written = Vec::new();
-    let mut files_skipped = Vec::new();
-    write_config(
-        root,
-        &config,
-        options.force,
-        &mut files_written,
-        &mut files_skipped,
-    )?;
+    let mut log = InstallLog::default();
+    let overwrite = options.force || options.refresh;
+    // Configuration is created once and then belongs to the repository: it holds
+    // the operating mode and any command the user tuned. Reinstalling files
+    // ForgeGuard ships is no reason to throw that away.
+    write_config(root, &config, &mut log)?;
     write_file(
         root,
         &root.join(".forgeguard/.gitignore"),
         FORGEGUARD_GITIGNORE,
-        options.force,
-        &mut files_written,
-        &mut files_skipped,
+        overwrite,
+        &mut log,
     )?;
 
     install_agents(
         root,
         InstallScope::Project,
         &options.agents,
-        options.force,
-        &mut files_written,
-        &mut files_skipped,
+        overwrite,
+        &mut log,
     )?;
-    refresh_stop_hook_timeouts(root, &mut files_written)?;
-    ignore_project_agent_directories(root, &options.agents, &mut files_written)?;
+    refresh_stop_hook_timeouts(root, &mut log.written)?;
+    ignore_project_agent_directories(root, &options.agents, &mut log)?;
 
     Ok(InitReport {
         detection,
         agents: expand_agent_targets(&options.agents),
-        files_written,
-        files_skipped,
+        files_written: log.written,
+        files_skipped: log.skipped,
+        files_outdated: log.outdated,
     })
 }
 
@@ -304,20 +320,19 @@ fn install_agents(
     scope: InstallScope,
     requested: &[AgentTarget],
     force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     for target in expand_agent_targets(requested) {
         match target {
-            AgentTarget::Codex => install_codex(root, scope, force, written, skipped)?,
-            AgentTarget::Claude => install_claude(root, scope, force, written, skipped)?,
-            AgentTarget::Cursor => install_cursor(root, scope, force, written, skipped)?,
-            AgentTarget::OpenCode => install_opencode(root, scope, force, written, skipped)?,
-            AgentTarget::Antigravity => install_antigravity(root, scope, force, written, skipped)?,
+            AgentTarget::Codex => install_codex(root, scope, force, log)?,
+            AgentTarget::Claude => install_claude(root, scope, force, log)?,
+            AgentTarget::Cursor => install_cursor(root, scope, force, log)?,
+            AgentTarget::OpenCode => install_opencode(root, scope, force, log)?,
+            AgentTarget::Antigravity => install_antigravity(root, scope, force, log)?,
             AgentTarget::Windsurf
             | AgentTarget::Copilot
             | AgentTarget::Cline
-            | AgentTarget::Roo => install_agents_md(root, target, scope, force, written, skipped)?,
+            | AgentTarget::Roo => install_agents_md(root, target, scope, force, log)?,
             AgentTarget::All => unreachable!("all is expanded before installation"),
         }
     }
@@ -348,7 +363,7 @@ fn expand_agent_targets(requested: &[AgentTarget]) -> Vec<AgentTarget> {
 fn ignore_project_agent_directories(
     root: &Path,
     requested: &[AgentTarget],
-    written: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let path = root.join(".gitignore");
     if !path.is_file() {
@@ -403,30 +418,26 @@ fn ignore_project_agent_directories(
     }
     if changed {
         fs::write(&path, content).with_context(|| format!("failed to write {}", path.display()))?;
-        record_path(root, &path, written);
+        record_path(root, &path, &mut log.written);
     }
     Ok(())
 }
 
-fn write_config(
-    root: &Path,
-    config: &ForgeGuardConfig,
-    force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
-) -> Result<()> {
+fn write_config(root: &Path, config: &ForgeGuardConfig, log: &mut InstallLog) -> Result<()> {
     let path = root.join(".forgeguard/config.toml");
+    if path.exists() {
+        return Ok(());
+    }
     let content =
         toml::to_string_pretty(config).context("failed to serialize ForgeGuard config")?;
-    write_file(root, &path, &content, force, written, skipped)
+    write_file(root, &path, &content, false, log)
 }
 
 fn install_codex(
     root: &Path,
     scope: InstallScope,
     force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     if force {
         remove_legacy_skills(root, ".codex/skills", true)?;
@@ -435,22 +446,15 @@ fn install_codex(
         InstallScope::Project => root.join("AGENTS.md"),
         InstallScope::Global => root.join(".codex/AGENTS.md"),
     };
-    write_file(root, &policy_path, AGENTS_TEMPLATE, force, written, skipped)?;
-    install_skill(
-        root,
-        ".agents/skills/forgeguard-engineering",
-        force,
-        written,
-        skipped,
-    )?;
+    write_file(root, &policy_path, AGENTS_TEMPLATE, force, log)?;
+    install_skill(root, ".agents/skills/forgeguard-engineering", force, log)?;
     install_grouped_hook(
         root,
         &root.join(".codex/hooks.json"),
         "Stop",
         None,
         CODEX_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )?;
     install_grouped_hook(
         root,
@@ -458,8 +462,7 @@ fn install_codex(
         "SessionStart",
         Some("startup|resume|compact"),
         CODEX_CONTEXT_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )?;
     install_grouped_hook(
         root,
@@ -467,8 +470,7 @@ fn install_codex(
         "PreToolUse",
         Some("apply_patch|Edit|Write"),
         CODEX_SCOPE_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )
 }
 
@@ -476,8 +478,7 @@ fn install_claude(
     root: &Path,
     scope: InstallScope,
     force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     if force {
         remove_legacy_skills(root, ".claude/skills", false)?;
@@ -486,22 +487,15 @@ fn install_claude(
         InstallScope::Project => root.join("CLAUDE.md"),
         InstallScope::Global => root.join(".claude/CLAUDE.md"),
     };
-    write_file(root, &policy_path, CLAUDE_TEMPLATE, force, written, skipped)?;
-    install_skill(
-        root,
-        ".claude/skills/forgeguard-engineering",
-        force,
-        written,
-        skipped,
-    )?;
+    write_file(root, &policy_path, CLAUDE_TEMPLATE, force, log)?;
+    install_skill(root, ".claude/skills/forgeguard-engineering", force, log)?;
     install_grouped_hook(
         root,
         &root.join(".claude/settings.json"),
         "Stop",
         None,
         CLAUDE_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )?;
     install_grouped_hook(
         root,
@@ -509,8 +503,7 @@ fn install_claude(
         "SessionStart",
         Some("startup|resume|compact"),
         CLAUDE_CONTEXT_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )?;
     install_grouped_hook(
         root,
@@ -518,8 +511,7 @@ fn install_claude(
         "UserPromptSubmit",
         None,
         CLAUDE_CONTEXT_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )?;
     install_grouped_hook(
         root,
@@ -527,8 +519,7 @@ fn install_claude(
         "PreToolUse",
         Some("Edit|Write|MultiEdit|NotebookEdit"),
         CLAUDE_SCOPE_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )
 }
 
@@ -536,39 +527,23 @@ fn install_cursor(
     root: &Path,
     scope: InstallScope,
     force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let rule_path = match scope {
         InstallScope::Project => root.join(".cursor/rules/forgeguard.mdc"),
         InstallScope::Global => root.join(".cursor/rules/forgeguard.mdc"),
     };
-    write_file(root, &rule_path, CURSOR_TEMPLATE, force, written, skipped)?;
-    install_skill(
-        root,
-        ".agents/skills/forgeguard-engineering",
-        force,
-        written,
-        skipped,
-    )?;
+    write_file(root, &rule_path, CURSOR_TEMPLATE, force, log)?;
+    install_skill(root, ".agents/skills/forgeguard-engineering", force, log)?;
     let path = root.join(".cursor/hooks.json");
-    install_cursor_hook(
-        root,
-        &path,
-        "stop",
-        None,
-        CURSOR_HOOK_COMMAND,
-        written,
-        skipped,
-    )?;
+    install_cursor_hook(root, &path, "stop", None, CURSOR_HOOK_COMMAND, log)?;
     install_cursor_hook(
         root,
         &path,
         "sessionStart",
         None,
         CURSOR_CONTEXT_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )?;
     install_cursor_hook(
         root,
@@ -576,8 +551,7 @@ fn install_cursor(
         "preToolUse",
         Some("Write|StrReplace|Delete|ApplyPatch"),
         CURSOR_SCOPE_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )
 }
 
@@ -585,8 +559,7 @@ fn install_opencode(
     root: &Path,
     scope: InstallScope,
     force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let (policy_path, skill_directory) = match scope {
         InstallScope::Project => (
@@ -598,16 +571,15 @@ fn install_opencode(
             ".config/opencode/skills/forgeguard-engineering",
         ),
     };
-    write_file(root, &policy_path, AGENTS_TEMPLATE, force, written, skipped)?;
-    install_skill(root, skill_directory, force, written, skipped)
+    write_file(root, &policy_path, AGENTS_TEMPLATE, force, log)?;
+    install_skill(root, skill_directory, force, log)
 }
 
 fn install_antigravity(
     root: &Path,
     scope: InstallScope,
     force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let (policy_path, skill_directory) = match scope {
         InstallScope::Project => (
@@ -622,8 +594,8 @@ fn install_antigravity(
     if force {
         remove_directory(root, OBSOLETE_GLOBAL_ANTIGRAVITY_SKILL_DIRECTORY)?;
     }
-    write_file(root, &policy_path, AGENTS_TEMPLATE, force, written, skipped)?;
-    install_skill(root, skill_directory, force, written, skipped)?;
+    write_file(root, &policy_path, AGENTS_TEMPLATE, force, log)?;
+    install_skill(root, skill_directory, force, log)?;
 
     // Only the workspace agent has a documented local hook file. Antigravity
     // publishes no user-level hook path, so a global install stops at rules and
@@ -632,29 +604,20 @@ fn install_antigravity(
         return Ok(());
     };
     let hook_path = root.join(".agents/hooks.json");
-    install_antigravity_simple_hook(
-        root,
-        &hook_path,
-        "Stop",
-        ANTIGRAVITY_HOOK_COMMAND,
-        written,
-        skipped,
-    )?;
+    install_antigravity_simple_hook(root, &hook_path, "Stop", ANTIGRAVITY_HOOK_COMMAND, log)?;
     install_antigravity_simple_hook(
         root,
         &hook_path,
         "PreInvocation",
         ANTIGRAVITY_CONTEXT_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )?;
     install_antigravity_tool_hook(
         root,
         &hook_path,
         "write_to_file|replace_file_content|multi_replace_file_content",
         ANTIGRAVITY_SCOPE_HOOK_COMMAND,
-        written,
-        skipped,
+        log,
     )
 }
 
@@ -672,8 +635,7 @@ fn install_agents_md(
     target: AgentTarget,
     scope: InstallScope,
     force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let relative = match scope {
         InstallScope::Project => "AGENTS.md",
@@ -682,14 +644,7 @@ fn install_agents_md(
             None => return Ok(()),
         },
     };
-    write_file(
-        root,
-        &root.join(relative),
-        AGENTS_TEMPLATE,
-        force,
-        written,
-        skipped,
-    )
+    write_file(root, &root.join(relative), AGENTS_TEMPLATE, force, log)
 }
 
 /// Where each `AGENTS.md`-only agent reads user-level rules from. `None` means the
@@ -708,16 +663,10 @@ fn global_policy_path(target: AgentTarget) -> Option<&'static str> {
     }
 }
 
-fn install_skill(
-    root: &Path,
-    directory: &str,
-    force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
-) -> Result<()> {
+fn install_skill(root: &Path, directory: &str, force: bool, log: &mut InstallLog) -> Result<()> {
     for (relative, content) in SKILL_ASSETS {
         let path = root.join(directory).join(relative);
-        write_file(root, &path, content, force, written, skipped)?;
+        write_file(root, &path, content, force, log)?;
     }
     if force {
         remove_obsolete_skill_assets(root, directory)?;
@@ -817,15 +766,14 @@ fn install_grouped_hook(
     event: &str,
     matcher: Option<&str>,
     command: &str,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let mut document = read_json_object(path)?;
     if document
         .pointer(&format!("/hooks/{event}"))
         .is_some_and(|hooks| contains_hook_command(hooks, command))
     {
-        record_path(root, path, skipped);
+        record_path(root, path, &mut log.skipped);
         return Ok(());
     }
     let hooks = object_field(&mut document, "hooks", path)?;
@@ -839,7 +787,7 @@ fn install_grouped_hook(
         handler["matcher"] = json!(matcher);
     }
     array_field(hooks, event, path)?.push(handler);
-    write_json_document(root, path, &document, written)
+    write_json_document(root, path, &document, &mut log.written)
 }
 
 fn install_cursor_hook(
@@ -848,12 +796,11 @@ fn install_cursor_hook(
     event: &str,
     matcher: Option<&str>,
     command: &str,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let mut document = read_json_object(path)?;
     if contains_string(&document, command) {
-        record_path(root, path, skipped);
+        record_path(root, path, &mut log.skipped);
         return Ok(());
     }
     document
@@ -870,7 +817,7 @@ fn install_cursor_hook(
         handler["matcher"] = json!(matcher);
     }
     array_field(hooks, event, path)?.push(handler);
-    write_json_document(root, path, &document, written)
+    write_json_document(root, path, &document, &mut log.written)
 }
 
 fn install_antigravity_simple_hook(
@@ -878,12 +825,11 @@ fn install_antigravity_simple_hook(
     path: &Path,
     event: &str,
     command: &str,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let mut document = read_json_object(path)?;
     if contains_string(&document, command) {
-        record_path(root, path, skipped);
+        record_path(root, path, &mut log.skipped);
         return Ok(());
     }
     let root_object = document.as_object_mut().expect("validated JSON object");
@@ -901,7 +847,7 @@ fn install_antigravity_simple_hook(
         "command": command,
         "timeout": if event == "Stop" { stop_hook_timeout_seconds(root) } else { 5 }
     }));
-    write_json_document(root, path, &document, written)
+    write_json_document(root, path, &document, &mut log.written)
 }
 
 fn install_antigravity_tool_hook(
@@ -909,12 +855,11 @@ fn install_antigravity_tool_hook(
     path: &Path,
     matcher: &str,
     command: &str,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let mut document = read_json_object(path)?;
     if contains_string(&document, command) {
-        record_path(root, path, skipped);
+        record_path(root, path, &mut log.skipped);
         return Ok(());
     }
     let root_object = document.as_object_mut().expect("validated JSON object");
@@ -935,7 +880,7 @@ fn install_antigravity_tool_hook(
             "timeout": 5
         }]
     }));
-    write_json_document(root, path, &document, written)
+    write_json_document(root, path, &document, &mut log.written)
 }
 
 fn read_json_object(path: &Path) -> Result<Value> {
@@ -1071,22 +1016,30 @@ fn write_file(
     path: &Path,
     content: &str,
     force: bool,
-    written: &mut Vec<String>,
-    skipped: &mut Vec<String>,
+    log: &mut InstallLog,
 ) -> Result<()> {
     let relative = path
         .strip_prefix(root)
         .unwrap_or(path)
         .display()
         .to_string();
-    if written.contains(&relative) {
+    if log.written.contains(&relative) {
         return Ok(());
     }
-    if path.exists() && !force {
-        if !skipped.contains(&relative) {
-            skipped.push(relative);
+    if path.exists() {
+        // A file matching the bundle needs nothing; one that differs is either
+        // an older release or something the user edited, and only the caller
+        // knows which. Either way it is reported, not quietly replaced.
+        let current = fs::read_to_string(path).unwrap_or_default();
+        if current == content {
+            record(&mut log.skipped, relative);
+            return Ok(());
         }
-        return Ok(());
+        if !force {
+            record(&mut log.outdated, relative.clone());
+            record(&mut log.skipped, relative);
+            return Ok(());
+        }
     }
     let parent = path
         .parent()
@@ -1096,8 +1049,12 @@ fn write_file(
     if !path.exists() {
         bail!("file was not created: {}", path.display());
     }
-    if !written.contains(&relative) {
-        written.push(relative);
-    }
+    record(&mut log.written, relative);
     Ok(())
+}
+
+fn record(records: &mut Vec<String>, value: String) {
+    if !records.contains(&value) {
+        records.push(value);
+    }
 }

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -174,14 +174,21 @@ const ALL_AGENT_TARGETS: &[AgentTarget] = &[
 /// Paths that show an agent is actually used here, checked in the order of
 /// `ALL_AGENT_TARGETS`. A target matches when any of its markers exists.
 ///
-/// Markers are the agent's own configuration, never ForgeGuard's output, so a
-/// repository that has never run `init` still reports the agents it uses.
+/// Markers are the agent's own configuration, so a repository that has never run
+/// `init` still reports the agents it uses. Where ForgeGuard writes into the same
+/// tree it only ever does so for that agent's own target, which keeps a repeat
+/// `init` on the same selection. `.agents/skills` is deliberately *not* a marker:
+/// Codex, Cursor, and OpenCode share it, so treating it as one would make every
+/// re-run silently add Antigravity.
 const PROJECT_AGENT_MARKERS: &[(AgentTarget, &[&str])] = &[
     (AgentTarget::Codex, &[".codex"]),
     (AgentTarget::Claude, &[".claude"]),
     (AgentTarget::Cursor, &[".cursor", ".cursorrules"]),
     (AgentTarget::OpenCode, &[".opencode", "opencode.json"]),
-    (AgentTarget::Antigravity, &[".agents", ".agent"]),
+    (
+        AgentTarget::Antigravity,
+        &[".agents/rules", ".agents/hooks.json", ".agent/rules"],
+    ),
     (
         AgentTarget::Windsurf,
         &[".windsurf", ".devin", ".windsurfrules"],

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -114,6 +114,10 @@ pub enum AgentTarget {
     Cursor,
     OpenCode,
     Antigravity,
+    Windsurf,
+    Copilot,
+    Cline,
+    Roo,
     All,
 }
 
@@ -135,6 +139,8 @@ impl Default for InitOptions {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InitReport {
     pub detection: ProjectDetection,
+    /// The targets actually installed, with `All` already expanded.
+    pub agents: Vec<AgentTarget>,
     pub files_written: Vec<String>,
     pub files_skipped: Vec<String>,
 }
@@ -142,6 +148,7 @@ pub struct InitReport {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GlobalInitReport {
     pub home: PathBuf,
+    pub agents: Vec<AgentTarget>,
     pub files_written: Vec<String>,
     pub files_skipped: Vec<String>,
 }
@@ -158,7 +165,62 @@ const ALL_AGENT_TARGETS: &[AgentTarget] = &[
     AgentTarget::Cursor,
     AgentTarget::OpenCode,
     AgentTarget::Antigravity,
+    AgentTarget::Windsurf,
+    AgentTarget::Copilot,
+    AgentTarget::Cline,
+    AgentTarget::Roo,
 ];
+
+/// Paths that show an agent is actually used here, checked in the order of
+/// `ALL_AGENT_TARGETS`. A target matches when any of its markers exists.
+///
+/// Markers are the agent's own configuration, never ForgeGuard's output, so a
+/// repository that has never run `init` still reports the agents it uses.
+const PROJECT_AGENT_MARKERS: &[(AgentTarget, &[&str])] = &[
+    (AgentTarget::Codex, &[".codex"]),
+    (AgentTarget::Claude, &[".claude"]),
+    (AgentTarget::Cursor, &[".cursor", ".cursorrules"]),
+    (AgentTarget::OpenCode, &[".opencode", "opencode.json"]),
+    (AgentTarget::Antigravity, &[".agents", ".agent"]),
+    (
+        AgentTarget::Windsurf,
+        &[".windsurf", ".devin", ".windsurfrules"],
+    ),
+    (
+        AgentTarget::Copilot,
+        &[".github/copilot-instructions.md", ".github/instructions"],
+    ),
+    (AgentTarget::Cline, &[".clinerules"]),
+    (AgentTarget::Roo, &[".roo", ".roorules"]),
+];
+
+/// Home-directory equivalents of `PROJECT_AGENT_MARKERS`. Cline and Copilot have
+/// no documented user-level rules directory, so they are absent here rather than
+/// guessed at.
+const GLOBAL_AGENT_MARKERS: &[(AgentTarget, &[&str])] = &[
+    (AgentTarget::Codex, &[".codex"]),
+    (AgentTarget::Claude, &[".claude"]),
+    (AgentTarget::Cursor, &[".cursor"]),
+    (AgentTarget::OpenCode, &[".config/opencode"]),
+    (AgentTarget::Antigravity, &[".gemini"]),
+    (AgentTarget::Windsurf, &[".codeium/windsurf", ".devin"]),
+    (AgentTarget::Roo, &[".roo"]),
+];
+
+/// Report which agents leave configuration under `root`, so `init` can install
+/// for those alone instead of writing every integration into every repository.
+pub fn detect_installed_agents(root: &Path, global: bool) -> Vec<AgentTarget> {
+    let markers = if global {
+        GLOBAL_AGENT_MARKERS
+    } else {
+        PROJECT_AGENT_MARKERS
+    };
+    markers
+        .iter()
+        .filter(|(_, paths)| paths.iter().any(|path| root.join(path).exists()))
+        .map(|(target, _)| *target)
+        .collect()
+}
 
 pub fn initialize_global(home: &Path, options: &InitOptions) -> Result<GlobalInitReport> {
     let home = home
@@ -178,6 +240,7 @@ pub fn initialize_global(home: &Path, options: &InitOptions) -> Result<GlobalIni
 
     Ok(GlobalInitReport {
         home,
+        agents: expand_agent_targets(&options.agents),
         files_written,
         files_skipped,
     })
@@ -222,6 +285,7 @@ pub fn initialize_project(root: &Path, options: &InitOptions) -> Result<InitRepo
 
     Ok(InitReport {
         detection,
+        agents: expand_agent_targets(&options.agents),
         files_written,
         files_skipped,
     })
@@ -242,6 +306,10 @@ fn install_agents(
             AgentTarget::Cursor => install_cursor(root, scope, force, written, skipped)?,
             AgentTarget::OpenCode => install_opencode(root, scope, force, written, skipped)?,
             AgentTarget::Antigravity => install_antigravity(root, scope, force, written, skipped)?,
+            AgentTarget::Windsurf
+            | AgentTarget::Copilot
+            | AgentTarget::Cline
+            | AgentTarget::Roo => install_agents_md(root, scope, force, written, skipped)?,
             AgentTarget::All => unreachable!("all is expanded before installation"),
         }
     }
@@ -580,6 +648,25 @@ fn install_antigravity(
         written,
         skipped,
     )
+}
+
+/// Windsurf, Copilot, Cline, and Roo all read `AGENTS.md` natively and expose no
+/// hook API ForgeGuard can drive, so supporting them costs one shared policy file
+/// and nothing else. They do not receive the engineering skill: none of them has a
+/// documented skill directory, and writing four near-duplicate rules files is the
+/// clutter this selection work exists to remove.
+fn install_agents_md(
+    root: &Path,
+    scope: InstallScope,
+    force: bool,
+    written: &mut Vec<String>,
+    skipped: &mut Vec<String>,
+) -> Result<()> {
+    let policy_path = match scope {
+        InstallScope::Project => root.join("AGENTS.md"),
+        InstallScope::Global => root.join(".agents/AGENTS.md"),
+    };
+    write_file(root, &policy_path, AGENTS_TEMPLATE, force, written, skipped)
 }
 
 fn install_skill(

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -13,13 +13,18 @@ const AGENTS_TEMPLATE: &str = include_str!("../assets/templates/AGENTS.md");
 const CLAUDE_TEMPLATE: &str = include_str!("../assets/templates/CLAUDE.md");
 const CURSOR_TEMPLATE: &str = include_str!("../assets/templates/CURSOR.md");
 const FORGEGUARD_GITIGNORE: &str = "cache/\nreports/\n";
-const AGENT_HOOK_FILES: [&str; 5] = [
+const AGENT_HOOK_FILES: [&str; 4] = [
     ".claude/settings.json",
     ".codex/hooks.json",
     ".cursor/hooks.json",
     ".agents/hooks.json",
-    ".gemini/config/hooks.json",
 ];
+/// Antigravity CLI moved global skills out of `.gemini/skills`; `.gemini/config`
+/// is documented only for `mcp_config.json`, never for skills or hooks.
+const GLOBAL_ANTIGRAVITY_SKILL_DIRECTORY: &str =
+    ".gemini/antigravity-cli/skills/forgeguard-engineering";
+const OBSOLETE_GLOBAL_ANTIGRAVITY_SKILL_DIRECTORY: &str =
+    ".gemini/config/skills/forgeguard-engineering";
 const DEFAULT_STOP_HOOK_TIMEOUT_SECONDS: u64 = 600;
 const MAX_STOP_HOOK_TIMEOUT_SECONDS: u64 = 3_600;
 /// Scan and report time on top of the configured command budget.
@@ -528,20 +533,29 @@ fn install_antigravity(
     written: &mut Vec<String>,
     skipped: &mut Vec<String>,
 ) -> Result<()> {
-    let (policy_path, skill_directory, hook_path) = match scope {
+    let (policy_path, skill_directory) = match scope {
         InstallScope::Project => (
             root.join(".agents/rules/forgeguard.md"),
             ".agents/skills/forgeguard-engineering",
-            root.join(".agents/hooks.json"),
         ),
         InstallScope::Global => (
             root.join(".gemini/GEMINI.md"),
-            ".gemini/config/skills/forgeguard-engineering",
-            root.join(".gemini/config/hooks.json"),
+            GLOBAL_ANTIGRAVITY_SKILL_DIRECTORY,
         ),
     };
+    if force {
+        remove_directory(root, OBSOLETE_GLOBAL_ANTIGRAVITY_SKILL_DIRECTORY)?;
+    }
     write_file(root, &policy_path, AGENTS_TEMPLATE, force, written, skipped)?;
     install_skill(root, skill_directory, force, written, skipped)?;
+
+    // Only the workspace agent has a documented local hook file. Antigravity
+    // publishes no user-level hook path, so a global install stops at rules and
+    // skills rather than writing a file no product reads.
+    let InstallScope::Project = scope else {
+        return Ok(());
+    };
+    let hook_path = root.join(".agents/hooks.json");
     install_antigravity_simple_hook(
         root,
         &hook_path,
@@ -910,6 +924,20 @@ fn remove_legacy_skills(root: &Path, directory: &str, include_engineering: bool)
         }
     }
     Ok(())
+}
+
+/// Drop a directory ForgeGuard used to install into. A symlink is unlinked rather
+/// than followed, so a user who points the path elsewhere does not lose that tree.
+fn remove_directory(root: &Path, relative: &str) -> Result<()> {
+    let path = root.join(relative);
+    let Ok(metadata) = fs::symlink_metadata(&path) else {
+        return Ok(());
+    };
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(&path).with_context(|| format!("failed to remove {}", path.display()))
+    } else {
+        fs::remove_file(&path).with_context(|| format!("failed to remove {}", path.display()))
+    }
 }
 
 fn write_file(

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -1026,6 +1026,14 @@ fn write_file(
     if log.written.contains(&relative) {
         return Ok(());
     }
+    // A symlink belongs to whoever made it. Writing through one edits the file
+    // at the other end instead: a repository that points AGENTS.md at CLAUDE.md
+    // would have its CLAUDE.md replaced by the AGENTS template, and the consent
+    // prompt would have named the wrong file. Leave it, and say so.
+    if fs::symlink_metadata(path).is_ok_and(|entry| entry.file_type().is_symlink()) {
+        record(&mut log.skipped, relative);
+        return Ok(());
+    }
     if path.exists() {
         // A file matching the bundle needs nothing; one that differs is either
         // an older release or something the user edited, and only the caller

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -201,9 +201,10 @@ const PROJECT_AGENT_MARKERS: &[(AgentTarget, &[&str])] = &[
     (AgentTarget::Roo, &[".roo", ".roorules"]),
 ];
 
-/// Home-directory equivalents of `PROJECT_AGENT_MARKERS`. Cline and Copilot have
-/// no documented user-level rules directory, so they are absent here rather than
-/// guessed at.
+/// Home-directory equivalents of `PROJECT_AGENT_MARKERS`. Copilot is absent
+/// because its instructions are repository-scoped, and Cline because the
+/// `~/.agents` directory it reads is also created by a global Codex or Cursor
+/// install, which would make it detect itself on the next run.
 const GLOBAL_AGENT_MARKERS: &[(AgentTarget, &[&str])] = &[
     (AgentTarget::Codex, &[".codex"]),
     (AgentTarget::Claude, &[".claude"]),
@@ -316,7 +317,7 @@ fn install_agents(
             AgentTarget::Windsurf
             | AgentTarget::Copilot
             | AgentTarget::Cline
-            | AgentTarget::Roo => install_agents_md(root, scope, force, written, skipped)?,
+            | AgentTarget::Roo => install_agents_md(root, target, scope, force, written, skipped)?,
             AgentTarget::All => unreachable!("all is expanded before installation"),
         }
     }
@@ -657,23 +658,54 @@ fn install_antigravity(
     )
 }
 
-/// Windsurf, Copilot, Cline, and Roo all read `AGENTS.md` natively and expose no
-/// hook API ForgeGuard can drive, so supporting them costs one shared policy file
-/// and nothing else. They do not receive the engineering skill: none of them has a
-/// documented skill directory, and writing four near-duplicate rules files is the
-/// clutter this selection work exists to remove.
+/// Windsurf, Copilot, Cline, and Roo all read a workspace `AGENTS.md` natively and
+/// expose no hook API ForgeGuard can drive, so supporting a project costs one
+/// shared policy file and nothing else. They do not receive the engineering skill:
+/// none of them has a documented skill directory, and writing four near-duplicate
+/// rules files is the clutter this selection work exists to remove.
+///
+/// User-level rules are not shared the same way, so a global install follows each
+/// agent's own documented path — or writes nothing when the agent documents none,
+/// rather than leaving a file no product reads.
 fn install_agents_md(
     root: &Path,
+    target: AgentTarget,
     scope: InstallScope,
     force: bool,
     written: &mut Vec<String>,
     skipped: &mut Vec<String>,
 ) -> Result<()> {
-    let policy_path = match scope {
-        InstallScope::Project => root.join("AGENTS.md"),
-        InstallScope::Global => root.join(".agents/AGENTS.md"),
+    let relative = match scope {
+        InstallScope::Project => "AGENTS.md",
+        InstallScope::Global => match global_policy_path(target) {
+            Some(path) => path,
+            None => return Ok(()),
+        },
     };
-    write_file(root, &policy_path, AGENTS_TEMPLATE, force, written, skipped)
+    write_file(
+        root,
+        &root.join(relative),
+        AGENTS_TEMPLATE,
+        force,
+        written,
+        skipped,
+    )
+}
+
+/// Where each `AGENTS.md`-only agent reads user-level rules from. `None` means the
+/// agent documents no user-level location, so a global install writes nothing for
+/// it rather than guessing.
+fn global_policy_path(target: AgentTarget) -> Option<&'static str> {
+    match target {
+        // Cline lists `~/.agents/AGENTS.md` among its rule sources.
+        AgentTarget::Cline => Some(".agents/AGENTS.md"),
+        // Windsurf/Devin reads AGENTS.md per workspace; globally it reads one file.
+        AgentTarget::Windsurf => Some(".codeium/windsurf/memories/global_rules.md"),
+        // Roo reads every file in its global rules directory.
+        AgentTarget::Roo => Some(".roo/rules/forgeguard.md"),
+        // Copilot instructions are repository-scoped only.
+        _ => None,
+    }
 }
 
 fn install_skill(

--- a/crates/forgeguard-core/src/lib.rs
+++ b/crates/forgeguard-core/src/lib.rs
@@ -28,7 +28,8 @@ pub use hook::{
     GoalContract, HookAgent, HookDecision, TaskState, TaskStatus, TaskTodo,
 };
 pub use init::{
-    initialize_global, initialize_project, AgentTarget, GlobalInitReport, InitOptions, InitReport,
+    detect_installed_agents, initialize_global, initialize_project, AgentTarget, GlobalInitReport,
+    InitOptions, InitReport,
 };
 pub use model::{CheckResult, EvidenceConfidence, Finding, GateReport, GateStatus, Severity};
 pub use rules::{LanguageCapability, RuleMetadata, LANGUAGE_CAPABILITIES, RULES};

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -635,3 +635,31 @@ fn force_prunes_the_superseded_global_antigravity_skill_directory() {
         .join(".gemini/antigravity-cli/skills/forgeguard-engineering/SKILL.md")
         .exists());
 }
+
+#[test]
+fn detection_is_stable_across_repeated_initialization() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("Cargo.toml"),
+        "[package]\nname = \"sample\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write manifest");
+    fs::create_dir_all(directory.path().join(".codex")).expect("create .codex");
+
+    let first = detect_installed_agents(directory.path(), false);
+    assert_eq!(first, vec![AgentTarget::Codex]);
+
+    initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: false,
+            agents: first.clone(),
+        },
+    )
+    .expect("install for codex");
+
+    // Codex shares `.agents/skills` with Cursor and OpenCode, so ForgeGuard's own
+    // output must not make the next run believe Antigravity is in use too.
+    assert!(directory.path().join(".agents/skills").exists());
+    assert_eq!(detect_installed_agents(directory.path(), false), first);
+}

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -837,6 +837,7 @@ fn force_reinstalls_files_but_keeps_configuration() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn a_symlinked_policy_file_is_never_written_through() {
     let directory = tempdir().expect("temp directory");

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -836,3 +836,39 @@ fn force_reinstalls_files_but_keeps_configuration() {
         "hand written\n"
     );
 }
+
+#[test]
+fn a_symlinked_policy_file_is_never_written_through() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("Cargo.toml"),
+        "[package]\nname = \"sample\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write manifest");
+    // Pointing AGENTS.md at CLAUDE.md is a common way to keep one policy file.
+    fs::write(directory.path().join("CLAUDE.md"), "hand written\n").expect("seed policy");
+    std::os::unix::fs::symlink("CLAUDE.md", directory.path().join("AGENTS.md"))
+        .expect("link AGENTS.md at CLAUDE.md");
+
+    initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: true,
+            refresh: false,
+            agents: vec![AgentTarget::Codex],
+        },
+    )
+    .expect("install for codex");
+
+    // Writing the Codex policy through the link would replace the file at the
+    // other end, and the refresh prompt would have named AGENTS.md while
+    // destroying CLAUDE.md.
+    assert_eq!(
+        fs::read_to_string(directory.path().join("CLAUDE.md")).expect("read policy"),
+        "hand written\n"
+    );
+    assert!(fs::symlink_metadata(directory.path().join("AGENTS.md"))
+        .expect("stat link")
+        .file_type()
+        .is_symlink());
+}

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -1,6 +1,8 @@
 use std::fs;
 
-use forgeguard_core::{initialize_project, AgentTarget, ForgeGuardConfig, InitOptions};
+use forgeguard_core::{
+    detect_installed_agents, initialize_project, AgentTarget, ForgeGuardConfig, InitOptions,
+};
 use tempfile::tempdir;
 
 #[test]
@@ -543,4 +545,93 @@ fn force_unlinks_legacy_symlink_without_removing_target() {
 
     assert!(!legacy.exists());
     assert!(target.join("keep.txt").exists());
+}
+
+#[test]
+fn detects_only_agents_with_configuration_present() {
+    let directory = tempdir().expect("temp directory");
+
+    assert!(detect_installed_agents(directory.path(), false).is_empty());
+
+    fs::create_dir_all(directory.path().join(".claude")).expect("create .claude");
+    fs::create_dir_all(directory.path().join(".roo/rules")).expect("create .roo/rules");
+    fs::create_dir_all(directory.path().join(".github")).expect("create .github");
+    fs::write(
+        directory.path().join(".github/copilot-instructions.md"),
+        "# rules\n",
+    )
+    .expect("write copilot instructions");
+
+    let detected = detect_installed_agents(directory.path(), false);
+
+    assert_eq!(
+        detected,
+        vec![AgentTarget::Claude, AgentTarget::Copilot, AgentTarget::Roo]
+    );
+}
+
+#[test]
+fn agents_md_only_targets_write_no_extra_directories() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("Cargo.toml"),
+        "[package]\nname = \"sample\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write manifest");
+
+    let report = initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: false,
+            agents: vec![
+                AgentTarget::Windsurf,
+                AgentTarget::Copilot,
+                AgentTarget::Cline,
+                AgentTarget::Roo,
+            ],
+        },
+    )
+    .expect("install AGENTS.md-only targets");
+
+    // One shared policy file plus ForgeGuard's own config, and nothing else:
+    // these four agents read AGENTS.md natively and expose no hook API.
+    assert_eq!(
+        report.files_written,
+        vec![
+            ".forgeguard/config.toml".to_owned(),
+            ".forgeguard/.gitignore".to_owned(),
+            "AGENTS.md".to_owned(),
+        ]
+    );
+    for unexpected in [".windsurf", ".clinerules", ".roo", ".github", ".agents"] {
+        assert!(
+            !directory.path().join(unexpected).exists(),
+            "{unexpected} should not be created"
+        );
+    }
+}
+
+#[test]
+fn force_prunes_the_superseded_global_antigravity_skill_directory() {
+    let directory = tempdir().expect("temp directory");
+    let obsolete = directory
+        .path()
+        .join(".gemini/config/skills/forgeguard-engineering");
+    fs::create_dir_all(&obsolete).expect("seed obsolete skill directory");
+    fs::write(obsolete.join("SKILL.md"), "stale\n").expect("write stale skill");
+
+    forgeguard_core::initialize_global(
+        directory.path(),
+        &InitOptions {
+            force: true,
+            agents: vec![AgentTarget::Antigravity],
+        },
+    )
+    .expect("refresh global antigravity install");
+
+    assert!(!obsolete.exists());
+    assert!(directory
+        .path()
+        .join(".gemini/antigravity-cli/skills/forgeguard-engineering/SKILL.md")
+        .exists());
 }

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -199,9 +199,12 @@ fn installs_global_skills_without_project_configuration() {
     assert!(directory.path().join(".gemini/GEMINI.md").exists());
     assert!(directory
         .path()
-        .join(".gemini/config/skills/forgeguard-engineering/SKILL.md")
+        .join(".gemini/antigravity-cli/skills/forgeguard-engineering/SKILL.md")
         .exists());
-    assert!(directory.path().join(".gemini/config/hooks.json").exists());
+    // `.gemini/config` is documented only for `mcp_config.json`, and Antigravity
+    // publishes no user-level hook file, so a global install writes neither.
+    assert!(!directory.path().join(".gemini/config").exists());
+    assert!(!directory.path().join(".gemini/hooks.json").exists());
     assert!(!directory.path().join(".forgeguard/config.toml").exists());
     assert!(!report.files_written.is_empty());
 }

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -18,6 +18,7 @@ fn installs_configuration_for_all_supported_agents() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![AgentTarget::All],
         },
     )
@@ -130,6 +131,7 @@ fn project_init_appends_installed_agent_directories_to_existing_gitignore() {
     fs::write(directory.path().join(".gitignore"), "target/\n/.codex/\n").expect("write gitignore");
     let options = InitOptions {
         force: false,
+        refresh: false,
         agents: vec![AgentTarget::All],
     };
 
@@ -152,6 +154,7 @@ fn project_init_ignores_only_directories_for_selected_agents() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![AgentTarget::Claude],
         },
     )
@@ -171,6 +174,7 @@ fn installs_global_skills_without_project_configuration() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![AgentTarget::All],
         },
     )
@@ -224,6 +228,7 @@ fn stop_hook_timeout_covers_the_configured_command_budget() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![AgentTarget::Claude],
         },
     )
@@ -274,6 +279,7 @@ fn reinitialization_repairs_a_stop_hook_timeout_below_the_command_budget() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![AgentTarget::Claude],
         },
     )
@@ -316,6 +322,7 @@ fn hook_install_preserves_existing_settings_and_is_idempotent() {
 
     let options = InitOptions {
         force: false,
+        refresh: false,
         agents: vec![AgentTarget::Claude],
     };
     initialize_project(directory.path(), &options).expect("first initialization");
@@ -371,6 +378,7 @@ fn force_removes_only_legacy_forgeguard_skills() {
         directory.path(),
         &InitOptions {
             force: true,
+            refresh: false,
             agents: vec![AgentTarget::Codex],
         },
     )
@@ -398,6 +406,7 @@ fn force_removes_obsolete_skill_reference() {
         directory.path(),
         &InitOptions {
             force: true,
+            refresh: false,
             agents: vec![AgentTarget::Codex],
         },
     )
@@ -420,6 +429,7 @@ fn non_force_preserves_obsolete_skill_reference() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![AgentTarget::Codex],
         },
     )
@@ -437,6 +447,7 @@ fn existing_policy_is_preserved_without_force() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![AgentTarget::Codex],
         },
     )
@@ -456,6 +467,7 @@ fn opencode_target_uses_shared_standards_without_unrelated_hooks() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![AgentTarget::OpenCode],
         },
     )
@@ -489,6 +501,7 @@ fn antigravity_hook_merge_is_idempotent() {
     .expect("write hooks");
     let options = InitOptions {
         force: false,
+        refresh: false,
         agents: vec![AgentTarget::Antigravity],
     };
 
@@ -538,6 +551,7 @@ fn force_unlinks_legacy_symlink_without_removing_target() {
         directory.path(),
         &InitOptions {
             force: true,
+            refresh: false,
             agents: vec![AgentTarget::Codex],
         },
     )
@@ -583,6 +597,7 @@ fn agents_md_only_targets_write_no_extra_directories() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![
                 AgentTarget::Windsurf,
                 AgentTarget::Copilot,
@@ -624,6 +639,7 @@ fn force_prunes_the_superseded_global_antigravity_skill_directory() {
         directory.path(),
         &InitOptions {
             force: true,
+            refresh: false,
             agents: vec![AgentTarget::Antigravity],
         },
     )
@@ -653,6 +669,7 @@ fn detection_is_stable_across_repeated_initialization() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: first.clone(),
         },
     )
@@ -672,6 +689,7 @@ fn global_agents_md_targets_follow_each_documented_user_path() {
         directory.path(),
         &InitOptions {
             force: false,
+            refresh: false,
             agents: vec![
                 AgentTarget::Windsurf,
                 AgentTarget::Copilot,
@@ -692,4 +710,129 @@ fn global_agents_md_targets_follow_each_documented_user_path() {
     assert!(directory.path().join(".roo/rules/forgeguard.md").is_file());
     // Copilot documents no user-level location, so nothing is written for it.
     assert!(!directory.path().join(".github").exists());
+}
+
+/// Seed a project installed for Claude, then drift two ForgeGuard-owned files.
+fn project_with_drift() -> tempfile::TempDir {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("Cargo.toml"),
+        "[package]\nname = \"sample\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write manifest");
+    initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: false,
+            refresh: false,
+            agents: vec![AgentTarget::Claude],
+        },
+    )
+    .expect("install for claude");
+    fs::write(directory.path().join("CLAUDE.md"), "hand written\n").expect("edit policy");
+    fs::write(
+        directory
+            .path()
+            .join(".claude/skills/forgeguard-engineering/SKILL.md"),
+        "from an older release\n",
+    )
+    .expect("age the skill");
+    directory
+}
+
+#[test]
+fn drifted_files_are_reported_and_left_alone() {
+    let directory = project_with_drift();
+
+    let report = initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: false,
+            refresh: false,
+            agents: vec![AgentTarget::Claude],
+        },
+    )
+    .expect("re-run init");
+
+    assert_eq!(
+        report.files_outdated,
+        vec![
+            "CLAUDE.md".to_owned(),
+            ".claude/skills/forgeguard-engineering/SKILL.md".to_owned(),
+        ]
+    );
+    // Reported, never rewritten: replacing a file the user may have edited is
+    // their decision, so a plain init leaves both exactly as they were.
+    assert_eq!(
+        fs::read_to_string(directory.path().join("CLAUDE.md")).expect("read policy"),
+        "hand written\n"
+    );
+    // Files that already match the bundle are not drift.
+    assert!(!report
+        .files_outdated
+        .iter()
+        .any(|path| path.contains("references/")));
+}
+
+#[test]
+fn refresh_replaces_drifted_files_without_touching_configuration() {
+    let directory = project_with_drift();
+    let configuration = directory.path().join(".forgeguard/config.toml");
+    let tuned = fs::read_to_string(&configuration)
+        .expect("read config")
+        .replace("mode = \"default\"", "mode = \"strict\"");
+    fs::write(&configuration, &tuned).expect("tune config");
+
+    let report = initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: false,
+            refresh: true,
+            agents: vec![AgentTarget::Claude],
+        },
+    )
+    .expect("refresh");
+
+    assert!(report.files_outdated.is_empty());
+    assert!(report.files_written.contains(&"CLAUDE.md".to_owned()));
+    assert_ne!(
+        fs::read_to_string(directory.path().join("CLAUDE.md")).expect("read policy"),
+        "hand written\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&configuration).expect("read config"),
+        tuned,
+        "refresh must not regenerate configuration"
+    );
+}
+
+#[test]
+fn force_reinstalls_files_but_keeps_configuration() {
+    let directory = project_with_drift();
+    let configuration = directory.path().join(".forgeguard/config.toml");
+    let tuned = fs::read_to_string(&configuration)
+        .expect("read config")
+        .replace("mode = \"default\"", "mode = \"strict\"");
+    fs::write(&configuration, &tuned).expect("tune config");
+
+    initialize_project(
+        directory.path(),
+        &InitOptions {
+            force: true,
+            refresh: false,
+            agents: vec![AgentTarget::Claude],
+        },
+    )
+    .expect("force reinstall");
+
+    // The operating mode and any tuned command belong to the repository; a
+    // reinstall of the files ForgeGuard ships is no reason to discard them.
+    assert_eq!(
+        fs::read_to_string(&configuration).expect("read config"),
+        tuned
+    );
+    assert_ne!(
+        fs::read_to_string(directory.path().join("CLAUDE.md")).expect("read policy"),
+        "hand written\n"
+    );
 }

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -663,3 +663,33 @@ fn detection_is_stable_across_repeated_initialization() {
     assert!(directory.path().join(".agents/skills").exists());
     assert_eq!(detect_installed_agents(directory.path(), false), first);
 }
+
+#[test]
+fn global_agents_md_targets_follow_each_documented_user_path() {
+    let directory = tempdir().expect("temp directory");
+
+    forgeguard_core::initialize_global(
+        directory.path(),
+        &InitOptions {
+            force: false,
+            agents: vec![
+                AgentTarget::Windsurf,
+                AgentTarget::Copilot,
+                AgentTarget::Cline,
+                AgentTarget::Roo,
+            ],
+        },
+    )
+    .expect("install global AGENTS.md-only targets");
+
+    // Each agent reads user-level rules from its own place; a shared
+    // `~/.agents/AGENTS.md` would be read by Cline alone.
+    assert!(directory.path().join(".agents/AGENTS.md").is_file());
+    assert!(directory
+        .path()
+        .join(".codeium/windsurf/memories/global_rules.md")
+        .is_file());
+    assert!(directory.path().join(".roo/rules/forgeguard.md").is_file());
+    // Copilot documents no user-level location, so nothing is written for it.
+    assert!(!directory.path().join(".github").exists());
+}

--- a/docs/FOCUS.md
+++ b/docs/FOCUS.md
@@ -118,7 +118,7 @@ No edit is required. Set `auto_poke = false` only to opt out, or lower `max_auto
 Upgrade the binary, then refresh bundled policies, skills, and hook entries:
 
 ```bash
-forgeguard init --agent all --force
+forgeguard init --force
 forgeguard doctor
 ```
 

--- a/install.ps1
+++ b/install.ps1
@@ -60,7 +60,7 @@ try {
     Write-Host ""
     Write-Host "ForgeGuard installed: $BinaryPath"
     Write-Host "Restart terminal, then run inside a repository:"
-    Write-Host "  forgeguard init --agent all"
+    Write-Host "  forgeguard init"
 }
 finally {
     Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $TemporaryDirectory

--- a/install.sh
+++ b/install.sh
@@ -115,4 +115,4 @@ fi
 echo
 echo "ForgeGuard installed: ${install_directory}/forgeguard"
 echo "Restart terminal, then run inside a repository:"
-echo "  forgeguard init --agent all"
+echo "  forgeguard init"

--- a/npm/README.md
+++ b/npm/README.md
@@ -28,7 +28,7 @@ Initialize ForgeGuard in a repository:
 
 ```bash
 cd your-project
-forgeguard init --agent all
+forgeguard init
 forgeguard doctor
 ```
 

--- a/tests/logo.sh
+++ b/tests/logo.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Regenerate the terminal logo grid in crates/forgeguard-cli/src/main.rs from
+# assets/brand/logo-mark.svg, so the banner and the real mark cannot drift apart.
+#
+#   sh tests/logo.sh          print the grid
+#   sh tests/logo.sh --check  fail if the committed grid differs from the SVG
+#
+# Needs macOS `qlmanage` and Python with Pillow — both developer-only, which is
+# why this is a helper rather than a build step. The grid is committed, so
+# building ForgeGuard never needs either.
+set -eu
+
+repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+command -v qlmanage >/dev/null 2>&1 || { echo "skip: qlmanage is macOS only" >&2; exit 0; }
+python3 -c 'import PIL' 2>/dev/null || { echo "skip: Pillow is not installed" >&2; exit 0; }
+
+# The shield and hammer only, over a chroma key that marks everything outside
+# the mark. The card background and rounded corners are dropped: the banner sits
+# on whatever background the terminal already has.
+sed -e 's|<rect width="32" height="32" rx="7" fill="#0a0a0a"/>|<rect width="32" height="32" fill="#ff00ff"/>|' \
+    -e 's|stroke="#0a0a0a"|stroke="#000000"|' \
+    "${repository_root}/assets/brand/logo-mark.svg" > "${work}/key.svg"
+
+qlmanage -t -s 512 -o "$work" "${work}/key.svg" >/dev/null 2>&1
+test -f "${work}/key.svg.png" || { echo "error: qlmanage produced no PNG" >&2; exit 1; }
+
+generate() {
+python3 - "$work" <<'PY'
+import sys
+from PIL import Image
+
+work = sys.argv[1]
+image = Image.open(f"{work}/key.svg.png").convert("RGB")
+
+
+def classify(pixel):
+    """Chroma key and QuickLook's white frame are transparent; the rest is the mark."""
+    red, green, blue = pixel
+    if (red > 150 and blue > 150 and green < 110) or red + green + blue > 600:
+        return " "
+    if green > red + 25 and green > blue + 25:
+        return "g"
+    if red + green + blue < 220:
+        return "d"
+    return "g"
+
+
+pixels = image.load()
+width, height = image.size
+columns = [x for x in range(width) if any(classify(pixels[x, y]) != " " for y in range(height))]
+rows = [y for y in range(height) if any(classify(pixels[x, y]) != " " for x in range(width))]
+mark = image.crop((min(columns), min(rows), max(columns) + 1, max(rows) + 1))
+
+# Twelve columns by twelve pixel rows renders as twelve columns by six text
+# rows, the smallest size at which the hammer inside the shield stays legible.
+scaled = mark.resize((12, 12), Image.LANCZOS).load()
+for y in range(12):
+    print('    "' + "".join(classify(scaled[x, y]) for x in range(12)) + '",')
+PY
+}
+
+source_file="${repository_root}/crates/forgeguard-cli/src/main.rs"
+
+if [ "${1:-}" = "--check" ]; then
+    generate > "${work}/expected"
+    # The committed grid is the twelve quoted rows following `const LOGO`.
+    sed -n '/const LOGO: \[&str; 12\]/,/^    \];/p' "$source_file" \
+        | grep -E '^        "' | sed 's/^    //' > "${work}/committed"
+    if diff -u "${work}/committed" "${work}/expected" > "${work}/delta"; then
+        echo "logo grid matches assets/brand/logo-mark.svg"
+    else
+        echo "error: the committed logo grid no longer matches the SVG" >&2
+        cat "${work}/delta" >&2
+        exit 1
+    fi
+else
+    generate
+fi

--- a/tests/sandbox.sh
+++ b/tests/sandbox.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# Build throwaway repositories under sandbox/ for trying `forgeguard init` by
+# hand. Not a CI test: nothing here asserts, it just sets up scenarios and runs
+# the non-interactive ones so you can read the output and poke at the results.
+#
+#   sh tests/sandbox.sh            build scenarios and show what each one does
+#   sh tests/sandbox.sh --clean    delete sandbox/ and stop
+#
+# sandbox/ is gitignored, and `forgeguard gate` skips gitignored paths, so
+# nothing in here affects the repository.
+set -eu
+
+repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+sandbox="${repository_root}/sandbox"
+binary="${FORGEGUARD_BINARY:-${repository_root}/target/debug/forgeguard}"
+
+if [ "${1:-}" = "--clean" ]; then
+    rm -rf "$sandbox"
+    echo "removed $sandbox"
+    exit 0
+fi
+
+test -x "$binary" || {
+    echo "error: no binary at $binary — run 'cargo build' first" >&2
+    exit 1
+}
+
+rm -rf "$sandbox"
+mkdir -p "$sandbox"
+
+# Each scenario is a git repository seeded with the marker directories of the
+# agents it is meant to look like, so detection has something real to find.
+scenario() {
+    name="$1"
+    shift
+    directory="${sandbox}/${name}"
+    mkdir -p "$directory"
+    git -C "$directory" init -q
+    for marker in "$@"; do
+        case "$marker" in
+            */) mkdir -p "${directory}/${marker}" ;;
+            *) mkdir -p "$(dirname "${directory}/${marker}")"; : > "${directory}/${marker}" ;;
+        esac
+    done
+    printf '%s' "$directory"
+}
+
+count_files() {
+    find "$1" -not -path '*/.git/*' -type f | wc -l | tr -d ' '
+}
+
+rule() {
+    printf '\n== %s ==\n' "$1"
+}
+
+empty="$(scenario empty)"
+rule "empty — no agent configured"
+echo "\$ forgeguard init"
+set +e
+(cd "$empty" && "$binary" init < /dev/null)
+echo "exit=$? files=$(count_files "$empty")"
+set -e
+
+claude_only="$(scenario claude .claude/)"
+rule "claude — one agent configured"
+echo "\$ forgeguard init"
+(cd "$claude_only" && "$binary" init < /dev/null) | grep -v '^Optional:'
+echo "files=$(count_files "$claude_only")"
+
+mixed="$(scenario mixed .claude/ .cursor/ .clinerules)"
+rule "mixed — three agents configured"
+echo "\$ forgeguard init"
+(cd "$mixed" && "$binary" init < /dev/null) | grep -v '^Optional:'
+echo "files=$(count_files "$mixed")"
+
+everything="$(scenario everything)"
+rule "everything — the old behaviour, for comparison"
+echo "\$ forgeguard init --agent all"
+(cd "$everything" && "$binary" init --agent all > /dev/null 2>&1)
+echo "files=$(count_files "$everything")"
+
+lean="$(scenario lean)"
+rule "lean — an AGENTS.md-only agent"
+echo "\$ forgeguard init --agent copilot"
+(cd "$lean" && "$binary" init --agent copilot < /dev/null) | grep -v '^Optional:'
+
+cat <<EOF
+
+Scenarios live in sandbox/ and are safe to edit or delete.
+
+Try the interactive picker, which needs a real terminal:
+
+  cd sandbox/mixed && ${binary} init
+
+Re-run init on a scenario to check the selection stays put:
+
+  cd sandbox/claude && ${binary} init
+
+Inspect what landed:
+
+  find sandbox/claude -not -path '*/.git/*' -type f | sort
+
+Start over:
+
+  sh tests/sandbox.sh          rebuild every scenario
+  sh tests/sandbox.sh --clean  delete sandbox/ entirely
+EOF

--- a/tests/wizard_test.sh
+++ b/tests/wizard_test.sh
@@ -7,7 +7,18 @@
 set -eu
 
 repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-binary="${FORGEGUARD_BINARY:-${repository_root}/target/debug/forgeguard}"
+# Prefer a debug build, which is what a developer has to hand, but fall back to
+# the release one: CI only ever runs `cargo build --release`, and `cargo test`
+# does not leave a plain binary behind.
+binary="${FORGEGUARD_BINARY:-}"
+if [ -z "$binary" ]; then
+    for candidate in debug release; do
+        if [ -x "${repository_root}/target/${candidate}/forgeguard" ]; then
+            binary="${repository_root}/target/${candidate}/forgeguard"
+            break
+        fi
+    done
+fi
 temporary_directory="$(mktemp -d)"
 trap 'rm -rf "$temporary_directory"' EXIT HUP INT TERM
 
@@ -15,7 +26,10 @@ if ! command -v script >/dev/null 2>&1; then
     echo "skip: script(1) is unavailable, cannot allocate a PTY" >&2
     exit 0
 fi
-test -x "$binary" || { echo "error: no binary at $binary" >&2; exit 1; }
+test -n "$binary" && test -x "$binary" || {
+    echo "error: no forgeguard binary under ${repository_root}/target; run 'cargo build' first" >&2
+    exit 1
+}
 
 # `script` differs between BSD and GNU: BSD takes the command as trailing
 # arguments, util-linux needs -c with the command as one string.

--- a/tests/wizard_test.sh
+++ b/tests/wizard_test.sh
@@ -17,13 +17,36 @@ if ! command -v script >/dev/null 2>&1; then
 fi
 test -x "$binary" || { echo "error: no binary at $binary" >&2; exit 1; }
 
-# `script` differs between BSD and GNU: BSD takes the command directly, GNU
-# needs -c and puts the file first.
+# `script` differs between BSD and GNU: BSD takes the command as trailing
+# arguments, util-linux needs -c with the command as one string.
+#
+# Detection reads --help rather than probing with a real run: a probe that
+# guesses wrong lands in an interactive shell and hangs CI instead of failing.
+# BSD script rejects long options, so its usage text never mentions --command.
+if script --help 2>&1 | grep -q -- '--command'; then
+    script_flavour="util-linux"
+else
+    script_flavour="bsd"
+fi
+
+# Belt and braces: if the flavour is ever misdetected, fail after a minute
+# rather than hanging the job. `timeout` is absent on a stock macOS.
+if command -v timeout >/dev/null 2>&1; then
+    bounded() { timeout 60 "$@"; }
+else
+    bounded() { "$@"; }
+fi
+
 run_on_pty() {
-    if script -q /dev/null true >/dev/null 2>&1; then
-        script -q /dev/null "$@"
+    if [ "$script_flavour" = "util-linux" ]; then
+        command_string="$1"
+        shift
+        for argument in "$@"; do
+            command_string="$command_string '$argument'"
+        done
+        bounded script -q -e -c "$command_string" /dev/null
     else
-        script -qefc "$*" /dev/null
+        bounded script -q /dev/null "$@"
     fi
 }
 strip_ansi() {
@@ -68,7 +91,9 @@ assert_contains "codex not preselected" "◻ codex"
 # The write summary is grouped rather than one line per file.
 assert_contains "result panel" "installed"
 assert_contains "agents line" "agents   claude, cursor"
-assert_contains "grouped writes" ".claude/ (13 files)"
+# Asserted as a prefix: the point is that the tree collapsed to one line, not
+# how many skill assets ForgeGuard happens to ship this release.
+assert_contains "grouped writes" ".claude/ ("
 
 # Accepting the pre-selection must install exactly those two agents.
 test -f "$project/CLAUDE.md" || { echo "error: CLAUDE.md missing" >&2; exit 1; }

--- a/tests/wizard_test.sh
+++ b/tests/wizard_test.sh
@@ -77,8 +77,15 @@ assert_contains() {
     fi
 }
 
-# The wizard ran at all.
-assert_contains "banner" "F O R G E G U A R D"
+# The wizard ran at all, and the banner drew the brand mark: half-blocks in the
+# shield colour, not just the wordmark next to them.
+assert_contains "wordmark" "ForgeGuard"
+for expected in '▀' '38;5;114'; do
+    if ! grep -qF "$expected" "$transcript"; then
+        echo "error: banner did not render the logo mark: $expected" >&2
+        exit 1
+    fi
+done
 # Detection reported both agents before the picker.
 assert_contains "detection step" "claude, cursor"
 # Rows carry what each target installs, not just a bare name.

--- a/tests/wizard_test.sh
+++ b/tests/wizard_test.sh
@@ -107,6 +107,32 @@ test -f "$project/CLAUDE.md" || { echo "error: CLAUDE.md missing" >&2; exit 1; }
 test -f "$project/.cursor/rules/forgeguard.mdc" || { echo "error: cursor rules missing" >&2; exit 1; }
 test ! -f "$project/AGENTS.md" || { echo "error: AGENTS.md written for an unselected agent" >&2; exit 1; }
 
+# A drifted ForgeGuard-owned file must be offered, not silently replaced.
+drift="${temporary_directory}/drift"
+mkdir -p "$drift/.claude"
+git -C "$drift" init -q
+"$binary" --root "$drift" init --agent claude >/dev/null 2>&1
+printf 'hand written\n' > "$drift/CLAUDE.md"
+{
+    sleep 0.6; printf '\r'
+    sleep 0.6; printf '\r'
+    sleep 1.0
+} | run_on_pty "$binary" --root "$drift" init --agent claude > "${temporary_directory}/drift-out" 2>&1 || true
+strip_ansi < "${temporary_directory}/drift-out" > "${temporary_directory}/drift-plain"
+
+for expected in "ForgeGuard file" "CLAUDE.md" "Replace them with the bundled versions?"; do
+    if ! grep -qF "$expected" "${temporary_directory}/drift-plain"; then
+        echo "error: refresh prompt never showed: $expected" >&2
+        cat "${temporary_directory}/drift-plain" >&2
+        exit 1
+    fi
+done
+# Enter accepts the default, which is to keep the file.
+if [ "$(cat "$drift/CLAUDE.md")" != "hand written" ]; then
+    echo "error: declining the prompt still replaced the file" >&2
+    exit 1
+fi
+
 # An empty pick must install nothing. Left arrow clears the selection, and two
 # empty confirmations cancel.
 empty="${temporary_directory}/empty"

--- a/tests/wizard_test.sh
+++ b/tests/wizard_test.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# Drive the interactive `forgeguard init` wizard through a pseudo-terminal.
+#
+# The wizard only runs when stdout is a TTY, so a plain pipe cannot reach it.
+# `script` allocates a PTY, and keystrokes are paced with sleeps because the
+# prompts read raw key events as they render rather than buffering a script.
+set -eu
+
+repository_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+binary="${FORGEGUARD_BINARY:-${repository_root}/target/debug/forgeguard}"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT HUP INT TERM
+
+if ! command -v script >/dev/null 2>&1; then
+    echo "skip: script(1) is unavailable, cannot allocate a PTY" >&2
+    exit 0
+fi
+test -x "$binary" || { echo "error: no binary at $binary" >&2; exit 1; }
+
+# `script` differs between BSD and GNU: BSD takes the command directly, GNU
+# needs -c and puts the file first.
+run_on_pty() {
+    if script -q /dev/null true >/dev/null 2>&1; then
+        script -q /dev/null "$@"
+    else
+        script -qefc "$*" /dev/null
+    fi
+}
+strip_ansi() {
+    sed 's/\x1b\[[0-9;?]*[a-zA-Z]//g'
+}
+
+project="${temporary_directory}/project"
+mkdir -p "$project/.claude" "$project/.cursor"
+git -C "$project" init -q
+
+# Enter x4: accept "This repository", accept the pre-selected agents, accept the
+# gitignore prompt, accept the mode prompt.
+transcript="${temporary_directory}/transcript"
+{
+    sleep 0.6; printf '\r'
+    sleep 0.6; printf '\r'
+    sleep 0.6; printf '\r'
+    sleep 0.6; printf '\r'
+    sleep 1.2
+} | run_on_pty "$binary" --root "$project" init > "$transcript" 2>&1 || true
+strip_ansi < "$transcript" > "${transcript}.plain"
+
+assert_contains() {
+    if ! grep -qF "$2" "${transcript}.plain"; then
+        echo "error: expected to find: $2" >&2
+        cat "${transcript}.plain" >&2
+        exit 1
+    fi
+}
+
+# The wizard ran at all.
+assert_contains "banner" "F O R G E G U A R D"
+# Detection reported both agents before the picker.
+assert_contains "detection step" "claude, cursor"
+# Rows carry what each target installs, not just a bare name.
+assert_contains "menu summary" "CLAUDE.md, own skill, Stop hook"
+assert_contains "AGENTS.md-only row" "AGENTS.md only"
+# Detected agents arrive pre-checked, everything else unchecked.
+assert_contains "claude preselected" "◼ claude"
+assert_contains "cursor preselected" "◼ cursor"
+assert_contains "codex not preselected" "◻ codex"
+# The write summary is grouped rather than one line per file.
+assert_contains "result panel" "installed"
+assert_contains "agents line" "agents   claude, cursor"
+assert_contains "grouped writes" ".claude/ (13 files)"
+
+# Accepting the pre-selection must install exactly those two agents.
+test -f "$project/CLAUDE.md" || { echo "error: CLAUDE.md missing" >&2; exit 1; }
+test -f "$project/.cursor/rules/forgeguard.mdc" || { echo "error: cursor rules missing" >&2; exit 1; }
+test ! -f "$project/AGENTS.md" || { echo "error: AGENTS.md written for an unselected agent" >&2; exit 1; }
+
+# An empty pick must install nothing. Left arrow clears the selection, and two
+# empty confirmations cancel.
+empty="${temporary_directory}/empty"
+mkdir -p "$empty/.claude"
+git -C "$empty" init -q
+{
+    sleep 0.6; printf '\r'
+    sleep 0.6; printf '\033[D'
+    sleep 0.3; printf '\r'
+    sleep 0.6; printf '\033[D'
+    sleep 0.3; printf '\r'
+    sleep 1.0
+} | run_on_pty "$binary" --root "$empty" init > "${temporary_directory}/empty-out" 2>&1 || true
+
+strip_ansi < "${temporary_directory}/empty-out" > "${temporary_directory}/empty-plain"
+if [ -f "$empty/CLAUDE.md" ]; then
+    echo "error: an empty selection installed files" >&2
+    cat "${temporary_directory}/empty-plain" >&2
+    exit 1
+fi
+# Guard against passing for the wrong reason: the run must have reached the
+# picker, been re-asked, and then cancelled.
+for expected in "nothing selected" "pick at least one" "no agent selected"; do
+    if ! grep -qF "$expected" "${temporary_directory}/empty-plain"; then
+        echo "error: empty-pick run never reached: $expected" >&2
+        cat "${temporary_directory}/empty-plain" >&2
+        exit 1
+    fi
+done
+
+echo "wizard test passed"


### PR DESCRIPTION
## Summary

- `forgeguard init` wrote every integration into every repository. A project that uses one assistant got **34 files** — `.claude/`, `.codex/`, `.cursor/`, `.agents/`, two skill trees, four hook files. It now installs only for the agents a directory actually uses: **16 files** for a Claude-only repo, **3** for an `AGENTS.md`-only tool.
- Overwriting was equally blunt: a plain `init` silently skipped stale files, so the engineering skill stayed a release behind, while `--force` replaced everything including `.forgeguard/config.toml`. Drifted files are now reported and, in a terminal, offered — defaulting to no.
- Four new targets (Windsurf/Devin, Copilot, Cline, Roo) cost one shared `AGENTS.md` between them and create no new directories.

## Behavior change worth reviewing

`forgeguard init` with no `--agent` and no terminal — a script, CI job, or an agent shelling out — used to install for **every** agent and exit 0. It now installs only for the agents it detects, and when it detects none it **writes nothing and exits 3**, printing the available choices.

```console
$ forgeguard init            # no agent configuration present
no agent configuration detected; nothing was installed.
Re-run with an explicit selection, for example:
  forgeguard init --agent claude
$ echo $?
3
```

- `--agent` is never second-guessed, so `--agent all` and every existing scripted call behave exactly as before. `install.sh` and `install.ps1` already pass `--agent all` and are unaffected.
- A CI job calling bare `forgeguard init` in a repository with no agent configuration will now fail. `--json` reports `{"needs_agent_selection": true, "choices": [...]}` for machine callers.
- Exit code `2` still means a blocked gate; `3` is new and only means "tell me which agent".

## Changes

**Agent selection** (`crates/forgeguard-core/src/init.rs`, `crates/forgeguard-cli/src/main.rs`)
- `detect_installed_agents` matches each target against the agent's own configuration — `.claude/`, `.codex/`, `.cursor/`, `.clinerules`, `.github/copilot-instructions.md`, and so on — never against ForgeGuard's own output.
- `--agent` accepts a list (`--agent claude,codex`) or repetition; previously one value, so multi-agent selection was reachable only through the wizard.
- The wizard pre-checks detected agents and treats an empty selection as "install nothing" rather than "install everything".
- `InitReport` and `GlobalInitReport` gained `agents` and `files_outdated`.

**Refresh flow**
- `init` compares installed ForgeGuard-owned files against the bundled ones. In a terminal it lists every drifted file and asks, defaulting to **no**; without a terminal it prints the same list and the command to run, and changes nothing.
- `--refresh` replaces drifted files without prompting. `--force` replaces every ForgeGuard-owned file, drifted or not.
- `.forgeguard/config.toml` is created once and then belongs to the repository — the operating mode and any tuned command now survive `--force`, which previously reset them.

**Correctness fixes found while building this**
- Never writes a policy file through a symlink. This repository points `AGENTS.md` at `CLAUDE.md`, and installing for Codex replaced `CLAUDE.md` with the AGENTS template — verified against `main`. The refresh prompt made it worse by naming `AGENTS.md` while the file destroyed was `CLAUDE.md`.
- Antigravity global paths corrected to `~/.gemini/antigravity-cli/skills/`, per the [Antigravity migration docs](https://antigravity.google/docs/cli/gcli-migration). The old `~/.gemini/config/skills/` and `~/.gemini/config/hooks.json` were read by nothing; `--force` prunes the stale directory. No separate `gemini` target: Gemini CLI stopped serving consumer requests on 18 Jun 2026.
- Detection no longer re-adds Antigravity on every run. `.agents/skills/` is shared by Codex, Cursor, and OpenCode, so a Codex-only repository detected Antigravity on its second `init`.
- The four new `AGENTS.md`-only targets follow each agent's own documented user-level path under `--global` (Cline `~/.agents/AGENTS.md`, Windsurf `~/.codeium/windsurf/memories/global_rules.md`, Roo `~/.roo/rules/`), and Copilot gets nothing because its instructions are repository-scoped.

**Output**
- Init output uses the same stdlib-only terminal theme as websift, so the CLIs read as one product; it collapses to plain text under `NO_COLOR` or a pipe.
- The banner draws the real shield-and-hammer mark sampled from `assets/brand/logo-mark.svg` via half-blocks. `tests/logo.sh --check` fails if the grid and the SVG drift apart.
- A single-agent install prints one grouped panel instead of 18 `created …` lines.

**Tests**
- `tests/wizard_test.sh` drives the interactive wizard through a pseudo-terminal and is wired into CI — the wizard previously had no automated coverage at all. Handles both BSD and util-linux `script`, with a `timeout` guard so a misdetection fails rather than hangs.
- `tests/sandbox.sh` builds throwaway scenarios under a gitignored `sandbox/` for trying `init` by hand.
- New integration tests for detection stability, `AGENTS.md`-only targets, drift reporting, refresh, config preservation, and symlink handling.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --locked --workspace` — 124 passed, 0 failed
- [x] `cargo build --locked --workspace --release`
- [x] `sh tests/install_test.sh`
- [x] `sh tests/wizard_test.sh` — passes on BSD `script` and through a util-linux-shaped shim
- [x] `sh tests/logo.sh --check` — banner grid matches the SVG
- [x] `cargo audit --deny warnings` — exit 0
- [x] `forgeguard gate --changed` — 0 errors, 0 warnings
- [x] No regressions: fresh installs are byte-identical to `main` for codex, claude, cursor, opencode, and antigravity
- [x] Upgrade path: an install created by `main` reports no drift under the new binary, so no existing user is nagged to refresh files that are already correct
- [x] `cargo deny check` and `cargo audit` — green in the `supply-chain` job; this branch adds no dependency and leaves `Cargo.lock` unchanged
