### PR TITLE
fix(init): never overwrite user-owned policy files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -376,6 +376,7 @@ fn execute() -> Result<ExitCode> {
                             theme::ACCENT,
                         )
                     );
+                    report_kept(&report.files_kept);
                     if offer_refresh(&report.files_outdated)? {
                         let report = initialize_global(
                             &home,
@@ -412,6 +413,7 @@ fn execute() -> Result<ExitCode> {
                         done.push_str("; ignored .forgeguard/ in .gitignore");
                     }
                     println!("{}\n", theme::point(&done, theme::ACCENT));
+                    report_kept(&report.files_kept);
                     if offer_refresh(&report.files_outdated)? {
                         let report = initialize_project(
                             &root,
@@ -1436,6 +1438,15 @@ fn summarize_paths(paths: &[String]) -> Vec<String> {
 /// so a stray Enter never costs anyone their work.
 ///
 /// Returns whether the caller should reinstall with `refresh` set.
+/// Files ForgeGuard found already written by the user. It never rewrites these,
+/// so the only thing left to do is say so — silence would read as "installed".
+fn report_kept(kept: &[String]) {
+    if kept.is_empty() {
+        return;
+    }
+    println!("{}", theme::panel(kept, "yours — left as-is", theme::AMBER));
+}
+
 fn offer_refresh(outdated: &[String]) -> Result<bool> {
     if outdated.is_empty() {
         return Ok(false);

--- a/crates/forgeguard-core/src/init.rs
+++ b/crates/forgeguard-core/src/init.rs
@@ -152,6 +152,8 @@ struct InstallLog {
     /// version. Replacing a file the user may have edited is their decision, so
     /// these are reported rather than silently rewritten.
     outdated: Vec<String>,
+    /// User-owned files left exactly as they were found.
+    kept: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -163,6 +165,8 @@ pub struct InitReport {
     pub files_skipped: Vec<String>,
     /// Existing ForgeGuard-owned files that differ from the bundled versions.
     pub files_outdated: Vec<String>,
+    /// Existing user-owned files ForgeGuard refused to rewrite.
+    pub files_kept: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -172,6 +176,7 @@ pub struct GlobalInitReport {
     pub files_written: Vec<String>,
     pub files_skipped: Vec<String>,
     pub files_outdated: Vec<String>,
+    pub files_kept: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -271,6 +276,7 @@ pub fn initialize_global(home: &Path, options: &InitOptions) -> Result<GlobalIni
         files_written: log.written,
         files_skipped: log.skipped,
         files_outdated: log.outdated,
+        files_kept: log.kept,
     })
 }
 
@@ -312,6 +318,7 @@ pub fn initialize_project(root: &Path, options: &InitOptions) -> Result<InitRepo
         files_written: log.written,
         files_skipped: log.skipped,
         files_outdated: log.outdated,
+        files_kept: log.kept,
     })
 }
 
@@ -1031,6 +1038,27 @@ fn remove_directory(root: &Path, relative: &str) -> Result<()> {
     }
 }
 
+/// Files that carry the user's own instructions alongside ForgeGuard's line.
+/// ForgeGuard seeds them when they are absent and never touches them again:
+/// rewriting one destroys work that was never ours, so no flag reaches them.
+/// Everything else ForgeGuard installs lives under a name or directory of its
+/// own, where the bundled copy is the only copy and refreshing is safe.
+const USER_OWNED_FILES: &[&str] = &[
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".claude/CLAUDE.md",
+    ".codex/AGENTS.md",
+    ".config/opencode/AGENTS.md",
+    ".gemini/GEMINI.md",
+    ".agents/AGENTS.md",
+    ".codeium/windsurf/memories/global_rules.md",
+];
+
+fn is_user_owned(relative: &str) -> bool {
+    let relative = relative.replace('\\', "/");
+    USER_OWNED_FILES.contains(&relative.as_str())
+}
+
 fn write_file(
     root: &Path,
     path: &Path,
@@ -1060,6 +1088,13 @@ fn write_file(
         // knows which. Either way it is reported, not quietly replaced.
         let current = fs::read_to_string(path).unwrap_or_default();
         if current == content {
+            record(&mut log.skipped, relative);
+            return Ok(());
+        }
+        // Checked before `overwrite` so that neither --force nor --refresh can
+        // reach the write below: the user's own file is not ours to replace.
+        if is_user_owned(&relative) {
+            record(&mut log.kept, relative.clone());
             record(&mut log.skipped, relative);
             return Ok(());
         }

--- a/crates/forgeguard-core/tests/init_test.rs
+++ b/crates/forgeguard-core/tests/init_test.rs
@@ -754,13 +754,13 @@ fn drifted_files_are_reported_and_left_alone() {
     )
     .expect("re-run init");
 
+    // CLAUDE.md is the user's file, so it is never a refresh candidate; only
+    // the skill, which ForgeGuard owns outright, can be offered for replacement.
     assert_eq!(
         report.files_outdated,
-        vec![
-            "CLAUDE.md".to_owned(),
-            ".claude/skills/forgeguard-engineering/SKILL.md".to_owned(),
-        ]
+        vec![".claude/skills/forgeguard-engineering/SKILL.md".to_owned()]
     );
+    assert_eq!(report.files_kept, vec!["CLAUDE.md".to_owned()]);
     // Reported, never rewritten: replacing a file the user may have edited is
     // their decision, so a plain init leaves both exactly as they were.
     assert_eq!(
@@ -794,8 +794,12 @@ fn refresh_replaces_drifted_files_without_touching_configuration() {
     .expect("refresh");
 
     assert!(report.files_outdated.is_empty());
-    assert!(report.files_written.contains(&"CLAUDE.md".to_owned()));
-    assert_ne!(
+    assert!(report
+        .files_written
+        .contains(&".claude/skills/forgeguard-engineering/SKILL.md".to_owned()));
+    // A refresh updates what ForgeGuard ships and stops there.
+    assert!(!report.files_written.contains(&"CLAUDE.md".to_owned()));
+    assert_eq!(
         fs::read_to_string(directory.path().join("CLAUDE.md")).expect("read policy"),
         "hand written\n"
     );
@@ -831,10 +835,50 @@ fn force_reinstalls_files_but_keeps_configuration() {
         fs::read_to_string(&configuration).expect("read config"),
         tuned
     );
-    assert_ne!(
+    assert_eq!(
         fs::read_to_string(directory.path().join("CLAUDE.md")).expect("read policy"),
         "hand written\n"
     );
+}
+
+/// The whole point of the guard: --force and --refresh exist to reinstall what
+/// ForgeGuard ships, and neither is a licence to rewrite the user's own file.
+#[test]
+fn a_user_edited_policy_file_survives_force_and_refresh() {
+    let directory = tempdir().expect("temp directory");
+    fs::write(
+        directory.path().join("Cargo.toml"),
+        "[package]\nname = \"sample\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write manifest");
+    fs::write(directory.path().join("CLAUDE.md"), "# My rules\n").expect("seed claude policy");
+    fs::write(directory.path().join("AGENTS.md"), "# My rules\n").expect("seed codex policy");
+
+    for options in [
+        InitOptions {
+            force: true,
+            refresh: false,
+            agents: vec![AgentTarget::Claude, AgentTarget::Codex],
+        },
+        InitOptions {
+            force: false,
+            refresh: true,
+            agents: vec![AgentTarget::Claude, AgentTarget::Codex],
+        },
+    ] {
+        let report = initialize_project(directory.path(), &options).expect("install");
+        assert_eq!(
+            report.files_kept,
+            vec!["CLAUDE.md".to_owned(), "AGENTS.md".to_owned()]
+        );
+        for policy in ["CLAUDE.md", "AGENTS.md"] {
+            assert_eq!(
+                fs::read_to_string(directory.path().join(policy)).expect("read policy"),
+                "# My rules\n",
+                "{policy} was rewritten"
+            );
+        }
+    }
 }
 
 #[cfg(unix)]

--- a/tests/wizard_test.sh
+++ b/tests/wizard_test.sh
@@ -121,12 +121,14 @@ test -f "$project/CLAUDE.md" || { echo "error: CLAUDE.md missing" >&2; exit 1; }
 test -f "$project/.cursor/rules/forgeguard.mdc" || { echo "error: cursor rules missing" >&2; exit 1; }
 test ! -f "$project/AGENTS.md" || { echo "error: AGENTS.md written for an unselected agent" >&2; exit 1; }
 
-# A drifted ForgeGuard-owned file must be offered, not silently replaced.
+# A drifted ForgeGuard-owned file must be offered, not silently replaced. An
+# edited CLAUDE.md is the user's file: it is reported as kept, never offered.
 drift="${temporary_directory}/drift"
 mkdir -p "$drift/.claude"
 git -C "$drift" init -q
 "$binary" --root "$drift" init --agent claude >/dev/null 2>&1
 printf 'hand written\n' > "$drift/CLAUDE.md"
+printf 'from an older release\n' > "$drift/.claude/skills/forgeguard-engineering/SKILL.md"
 {
     sleep 0.6; printf '\r'
     sleep 0.6; printf '\r'
@@ -134,7 +136,7 @@ printf 'hand written\n' > "$drift/CLAUDE.md"
 } | run_on_pty "$binary" --root "$drift" init --agent claude > "${temporary_directory}/drift-out" 2>&1 || true
 strip_ansi < "${temporary_directory}/drift-out" > "${temporary_directory}/drift-plain"
 
-for expected in "ForgeGuard file" "CLAUDE.md" "Replace them with the bundled versions?"; do
+for expected in "ForgeGuard file" "SKILL.md" "Replace them with the bundled versions?" "left as-is" "CLAUDE.md"; do
     if ! grep -qF "$expected" "${temporary_directory}/drift-plain"; then
         echo "error: refresh prompt never showed: $expected" >&2
         cat "${temporary_directory}/drift-plain" >&2
@@ -144,6 +146,13 @@ done
 # Enter accepts the default, which is to keep the file.
 if [ "$(cat "$drift/CLAUDE.md")" != "hand written" ]; then
     echo "error: declining the prompt still replaced the file" >&2
+    exit 1
+fi
+# CLAUDE.md belongs to the user, so it is never one of the files the prompt
+# offers to replace.
+if grep -A4 -F "differ from this version" "${temporary_directory}/drift-plain" | grep -qF "CLAUDE.md"; then
+    echo "error: refresh prompt offered to replace the user's CLAUDE.md" >&2
+    cat "${temporary_directory}/drift-plain" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- `forgeguard init --force` / `--refresh`, and a yes to the refresh prompt, replaced the user's `CLAUDE.md` and `AGENTS.md` with the three-line bundled template, with no backup kept.
- The refresh prompt asked once for every drifted file at once, so updating a stale skill destroyed a hand-written policy file in the same keystroke.
- These files hold the user's own instructions. ForgeGuard now seeds them when absent and never rewrites them under any flag; files it names itself keep refreshing as before.

## Changes

**`crates/forgeguard-core/src/init.rs`**
- Add `USER_OWNED_FILES` and `is_user_owned`, covering `CLAUDE.md`, `AGENTS.md` and their global twins (`.claude/CLAUDE.md`, `.codex/AGENTS.md`, `.config/opencode/AGENTS.md`, `.gemini/GEMINI.md`, `.agents/AGENTS.md`, `.codeium/windsurf/memories/global_rules.md`). Path separators are normalised so the check holds on Windows.
- Check it in `write_file` **ahead of** the `overwrite` branch, so no flag can reach the `fs::write`. One place, so a new agent target cannot forget the rule.
- Report the outcome: `kept` on `InstallLog`, `files_kept` on `InitReport` and `GlobalInitReport`.
- Deliberately excluded, since the bundled copy is the only copy: `.cursor/rules/forgeguard.mdc`, `.agents/rules/forgeguard.md`, `.roo/rules/forgeguard.md`, everything under `*/skills/forgeguard-engineering/`.

**`crates/forgeguard-cli/src/main.rs`**
- `report_kept` names the files that were left alone; a silent skip reads as "installed".
- `offer_refresh` now receives only genuinely refreshable files, so "Replace them with the bundled versions?" stops being a lie about `CLAUDE.md`.

**Tests**
- `init_test.rs`: three tests asserted the old behaviour and pinned the bug in place; new `a_user_edited_policy_file_survives_force_and_refresh` covers both flags.
- `wizard_test.sh`: drifts the skill as well, which is what the prompt is for, and asserts the user's file is never among the files offered for replacement.

**`Cargo.lock`** — separate commit. Release 0.12.0 bumped the crate manifest but left the lockfile at 0.11.2, so every `--locked` step in CI refuses to run. Pre-existing on `main`, fixed here so this branch can go green.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked --workspace` — 17 suites, 125 tests, 0 failures
- [x] `cargo build --locked --workspace --release`
- [x] `sh tests/install_test.sh` (exit 0) and `sh tests/wizard_test.sh`
- [x] A/B measurement in a sandbox: a binary built from `main@5f5e299` rewrote **4 of 6** seeded policy files across `init`, `--force` and `--refresh`; this branch rewrites **0 of 6**
- [x] Guardrails under `--refresh`: a drifted `SKILL.md` is still replaced, `.forgeguard/config.toml` keeps a tuned `mode = "strict"`, an edited `CLAUDE.md` survives
- [x] A fresh repository still gets `CLAUDE.md` and `AGENTS.md` seeded
- [x] `--json` gains `files_kept` additively; `--agent all` over an existing `AGENTS.md` reports it once, with no duplicates
- [x] `NO_COLOR=1` output contains no ANSI escapes

## Known consequence

Once a policy file exists and differs from the bundle it is the user's, so a future change to the bundled template will not reach them automatically. The CLI names those files on every run so the choice stays visible.