### PR TITLE
chore(release): prepare v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/forgeguard-cli/CHANGELOG.md
+++ b/crates/forgeguard-cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.13.1](https://github.com/suiflex/ForgeGuard/compare/v0.13.0...v0.13.1) (2026-08-22)
+
+### Features
+
+* expand General Guard with open-ended role profiles, acceptance coverage, evidence provenance, artifacts, and MCP/resource scope controls
+* add global Hermes and OpenClaw integrations
+* add changed-code security, coverage, duplication, SARIF, and opt-in supply-chain quality gates
+
+### Bug Fixes
+
+* prevent global General Guard hooks from duplicating project Code Guard lifecycle events
+* preserve disabled global focus settings, repository-scoped Code Guard modes, unrelated hooks, and existing configuration during upgrades
+
+### Documentation
+
+* make the README problem-first and add concrete contributor onboarding, roadmap lanes, and GitHub contribution forms
+
 ## [0.13.0](https://github.com/suiflex/ForgeGuard/compare/v0.12.0...v0.13.0) (2026-08-17)
 
 

--- a/crates/forgeguard-cli/Cargo.toml
+++ b/crates/forgeguard-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forgeguard"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/forgeguard",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Token-efficient quality layer for AI coding agents",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- bump ForgeGuard CLI and npm package to 0.13.1
- synchronize Cargo.lock
- document merged General Guard, quality gate, agent integration, onboarding, and duplicate-hook fixes

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace
- cargo build --locked --workspace --release
- cargo deny check
- cargo audit --deny warnings
- sh -n install.sh
- sh tests/install_test.sh
- env -u NO_COLOR FORGEGUARD_BINARY=target/release/forgeguard sh tests/wizard_test.sh
- npm pack --dry-run
- target/release/forgeguard gate --changed --output compact