### PR TITLE
fix: unblock CI on clippy 1.98

### DIFF
--- a/crates/forgeguard-core/src/git.rs
+++ b/crates/forgeguard-core/src/git.rs
@@ -195,7 +195,7 @@ fn parse_added_range(line: &str) -> Option<(usize, usize)> {
     let (start, count) = range
         .strip_prefix('+')?
         .split_once(',')
-        .map_or((range.strip_prefix('+')?, "1"), |parts| parts);
+        .unwrap_or((range.strip_prefix('+')?, "1"));
     let start: usize = start.parse().ok()?;
     let count: usize = count.parse().ok()?;
     (count > 0).then(|| (start, start.saturating_add(count - 1)))


### PR DESCRIPTION
## Summary

- CI on `main` last passed on 24 August and now fails on unchanged code. Nothing in the repository moved; clippy did.
- Clippy 1.98 added the `map_or_identity` lint. Both `ci.yml` and `rust-toolchain.toml` resolve `stable` at run time, so a new lint reaches CI the moment it ships and `-D warnings` turns it into a build failure.
- This blocks every open pull request, not just one.

## Changes

- `crates/forgeguard-core/src/git.rs` — rewrites the hunk-header parser's fallback from `map_or(default, |parts| parts)` to `unwrap_or(default)`.

`map_or(default, |x| x)` is the definition of `unwrap_or(default)`. Both evaluate the default eagerly, so there is no runtime difference — including for the `?` inside the default expression, which was already evaluated on every call.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p forgeguard-core --all-targets --all-features -- -D warnings`
- [x] `cargo test -p forgeguard-core` — 76 tests pass
- [ ] CI confirms the lint is gone

Worth noting: the local toolchain here is clippy 0.1.95, which predates the lint, so the failure could not be reproduced locally. What is verified is that the change compiles clean and breaks nothing; CI is the authority on the lint itself.

## Follow-up worth considering

Staying on `stable` with `-D warnings` means CI can go red without anyone touching the code, every time clippy ships a lint. Pinning a Rust version in `ci.yml` would stop the surprise, at the cost of finding out about genuinely useful lints later. Left as a separate decision.