### PR TITLE
feat: install updates directly from forgeguard update

### DIFF
--- a/.forgeguard/config.toml
+++ b/.forgeguard/config.toml
@@ -1,5 +1,5 @@
 version = 2
-mode = "default"
+mode = "strict"
 
 [project]
 name = "ForgeGuard"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "forgeguard"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ The version in `npm/package.json` must match the GitHub Release tag, and release
 
 ## Updating
 
-`forgeguard update` only *checks* whether a newer release exists and prints a one-line
-notice; it never installs anything. Upgrading is re-running the installer, then refreshing the
-assets ForgeGuard already wrote.
+`forgeguard update` checks whether a newer release exists and automatically installs
+the latest version if an update is available. Pass `--check` to check for updates
+without installing.
 
 ### Upgrade the binary and global assets
 
@@ -190,12 +190,17 @@ Check the installed version at any time:
 forgeguard --version
 ```
 
-Check whether a newer release exists (checks only; installs nothing):
+Check whether a newer release exists without installing:
+
+```bash
+forgeguard update --check
+```
+
+Update ForgeGuard directly to the latest release:
 
 ```bash
 forgeguard update
 ```
-
 ### Refresh an already-initialized project
 
 New releases can ship updated policy files and engineering skills. A plain `forgeguard init`

--- a/crates/forgeguard-cli/src/main.rs
+++ b/crates/forgeguard-cli/src/main.rs
@@ -128,17 +128,21 @@ enum Commands {
         #[command(subcommand)]
         command: Box<TaskCommands>,
     },
-    /// Check for a newer release, or change the update policy.
+    /// Update ForgeGuard to the latest release, check for updates, or change the update policy.
     ///
-    /// With no `--mode`, checks and prints a notice; `auto`/`off` never
-    /// install anything. `ask` mode also gates other TTY-run commands
-    /// (`init`, `doctor`, `gate`, `review`, `baseline`) with a y/n prompt
-    /// when a newer version is cached, and installs only on explicit "yes".
+    /// Running `forgeguard update` checks for a newer release and installs it
+    /// directly if available. Pass `--check` to check without installing.
     Update {
+        /// Only check for updates without installing
+        #[arg(long)]
+        check: bool,
+        /// Update policy to set (`auto`, `ask`, `off`)
         #[arg(long, value_enum)]
         mode: Option<UpdatePolicyArg>,
+        /// Apply update policy globally
         #[arg(long)]
         global: bool,
+        /// Output in JSON format
         #[arg(long)]
         json: bool,
     },
@@ -636,12 +640,18 @@ fn execute() -> Result<ExitCode> {
             command: HookCommands::Scope { agent, global },
         } => execute_scope_hook(&root, agent.into(), global),
         Commands::Task { command } => execute_task(&root, *command),
-        Commands::Update { mode, global, json } => execute_update(&root, mode, global, json),
+        Commands::Update {
+            check,
+            mode,
+            global,
+            json,
+        } => execute_update(&root, check, mode, global, json),
     }
 }
 
 fn execute_update(
     root: &Path,
+    check: bool,
     mode: Option<UpdatePolicyArg>,
     global: bool,
     json: bool,
@@ -674,11 +684,130 @@ fn execute_update(
     }
 
     let home = home_directory()?;
-    match forgeguard_core::update::refresh_for(&home, true, VERSION) {
-        Some(notice) => println!("{notice}"),
-        None => println!("ForgeGuard {VERSION} is up to date."),
+    let update_info = forgeguard_core::update::check_for_update_for(&home, true, VERSION);
+
+    if check {
+        match update_info {
+            Some(info) if info.update_available => {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "status": "update_available",
+                            "current": info.current,
+                            "latest": info.latest,
+                            "update_available": true,
+                        })
+                    );
+                } else {
+                    println!(
+                        "A newer version of ForgeGuard is available: {} (current: {}).",
+                        info.latest, info.current
+                    );
+                    println!("Run `forgeguard update` to install the update.");
+                }
+            }
+            Some(info) => {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "status": "up_to_date",
+                            "version": info.current,
+                            "update_available": false,
+                        })
+                    );
+                } else {
+                    println!("ForgeGuard {} is up to date.", info.current);
+                }
+            }
+            None => {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "status": "unknown",
+                            "version": VERSION,
+                            "update_available": false,
+                        })
+                    );
+                } else {
+                    println!(
+                        "ForgeGuard {VERSION} is up to date (could not check remote release)."
+                    );
+                }
+            }
+        }
+        return Ok(ExitCode::SUCCESS);
     }
-    Ok(ExitCode::SUCCESS)
+
+    match update_info {
+        Some(info) if info.update_available => {
+            if !json {
+                println!(
+                    "Updating ForgeGuard from v{} to v{}...",
+                    info.current, info.latest
+                );
+            }
+            let status = forgeguard_core::update::run_install_command()?;
+            if status.success() {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "status": "updated",
+                            "from": info.current,
+                            "to": info.latest,
+                        })
+                    );
+                } else {
+                    println!("ForgeGuard successfully updated to v{}.", info.latest);
+                }
+                Ok(ExitCode::SUCCESS)
+            } else {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "status": "error",
+                            "message": format!("Update installer exited with {status}"),
+                        })
+                    );
+                } else {
+                    eprintln!("ForgeGuard update command exited with {status}.");
+                }
+                Ok(ExitCode::from(1))
+            }
+        }
+        Some(info) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "status": "up_to_date",
+                        "version": info.current,
+                    })
+                );
+            } else {
+                println!("ForgeGuard {} is up to date.", info.current);
+            }
+            Ok(ExitCode::SUCCESS)
+        }
+        None => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "status": "up_to_date",
+                        "version": VERSION,
+                    })
+                );
+            } else {
+                println!("ForgeGuard {VERSION} is up to date (could not check remote release).");
+            }
+            Ok(ExitCode::SUCCESS)
+        }
+    }
 }
 
 fn execute_mode(root: &Path, mode: Option<ModeArg>, global: bool, json: bool) -> Result<ExitCode> {

--- a/crates/forgeguard-core/src/update.rs
+++ b/crates/forgeguard-core/src/update.rs
@@ -17,7 +17,11 @@ use serde::{Deserialize, Serialize};
 
 const REPOSITORY_URL: &str = "https://github.com/suiflex/ForgeGuard";
 const CACHE_RELATIVE: &str = ".forgeguard/update-check.json";
-const INSTALL_COMMAND: &str =
+#[cfg(windows)]
+pub const INSTALL_COMMAND: &str =
+    "irm https://raw.githubusercontent.com/suiflex/ForgeGuard/main/install.ps1 | iex";
+#[cfg(not(windows))]
+pub const INSTALL_COMMAND: &str =
     "curl -fsSL https://raw.githubusercontent.com/suiflex/ForgeGuard/main/install.sh | sh";
 const THROTTLE_SECONDS: u64 = 86_400;
 
@@ -31,6 +35,47 @@ struct UpdateCache {
     latest: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateCheck {
+    pub current: String,
+    pub latest: String,
+    pub update_available: bool,
+}
+
+/// Query whether a newer release exists, checking the remote if the cache is stale
+/// or `force` is true.
+pub fn check_for_update(home: &Path, force: bool) -> Option<UpdateCheck> {
+    check_for_update_for(home, force, current_version())
+}
+
+pub fn check_for_update_for(
+    home: &Path,
+    force: bool,
+    current_version: &str,
+) -> Option<UpdateCheck> {
+    if force || is_stale(home) {
+        if let Some(latest) = fetch_latest_version() {
+            write_cache(
+                home,
+                &UpdateCache {
+                    checked_at: now_seconds(),
+                    latest,
+                },
+            );
+        }
+    }
+    let cache = read_cache(home)?;
+    let latest = cache.latest;
+    let update_available = match (parse_version(&latest), parse_version(current_version)) {
+        (Some(latest_ver), Some(current_ver)) => latest_ver > current_ver,
+        _ => false,
+    };
+    Some(UpdateCheck {
+        current: current_version.to_owned(),
+        latest,
+        update_available,
+    })
+}
 /// One-line optional notice built from the cached latest version. Never touches
 /// the network; safe to call on every hook invocation.
 pub fn cached_notice(home: &Path) -> Option<String> {
@@ -50,18 +95,12 @@ pub fn refresh(home: &Path, force: bool) -> Option<String> {
 }
 
 pub fn refresh_for(home: &Path, force: bool, current_version: &str) -> Option<String> {
-    if force || is_stale(home) {
-        if let Some(latest) = fetch_latest_version() {
-            write_cache(
-                home,
-                &UpdateCache {
-                    checked_at: now_seconds(),
-                    latest,
-                },
-            );
-        }
+    let check = check_for_update_for(home, force, current_version)?;
+    if check.update_available {
+        notice(current_version, &check.latest)
+    } else {
+        None
     }
-    cached_notice_for(home, current_version)
 }
 
 /// Launch a detached refresh when the cache is missing or older than the
@@ -76,7 +115,7 @@ pub fn spawn_refresh_if_stale(home: &Path) {
     };
     let _ = Command::new(executable)
         .arg("update")
-        .stdin(Stdio::null())
+        .arg("--check")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn();
@@ -86,10 +125,27 @@ pub fn spawn_refresh_if_stale(home: &Path) {
 /// (`curl -fsSL .../install.sh | sh`), with inherited stdio so install output
 /// is visible. Used only when a user has explicitly confirmed an `ask`-mode
 /// update prompt; never called automatically.
+#[cfg(not(windows))]
 pub fn run_install_command() -> io::Result<ExitStatus> {
     Command::new("sh")
         .arg("-c")
         .arg(INSTALL_COMMAND)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+}
+
+#[cfg(windows)]
+pub fn run_install_command() -> io::Result<ExitStatus> {
+    Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            INSTALL_COMMAND,
+        ])
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -188,5 +244,27 @@ mod tests {
         assert!(notice("0.2.0", "0.3.0").is_some());
         assert!(notice("0.2.0", "0.2.0").is_none());
         assert!(notice("0.3.0", "0.2.9").is_none());
+    }
+
+    #[test]
+    fn check_for_update_detects_newer_version() {
+        let home = tempfile::tempdir().expect("temp home");
+        write_cache(
+            home.path(),
+            &UpdateCache {
+                checked_at: now_seconds(),
+                latest: "1.0.0".to_owned(),
+            },
+        );
+        let check = check_for_update_for(home.path(), false, "0.9.0").expect("check result");
+        assert_eq!(check.current, "0.9.0");
+        assert_eq!(check.latest, "1.0.0");
+        assert!(check.update_available);
+
+        let same = check_for_update_for(home.path(), false, "1.0.0").expect("check result");
+        assert!(!same.update_available);
+
+        let older = check_for_update_for(home.path(), false, "1.1.0").expect("check result");
+        assert!(!older.update_available);
     }
 }

--- a/crates/forgeguard-core/tests/update_test.rs
+++ b/crates/forgeguard-core/tests/update_test.rs
@@ -1,14 +1,28 @@
 use std::fs;
 
-use forgeguard_core::update::{cached_notice, cached_notice_for, current_version};
+use forgeguard_core::update::{
+    cached_notice, cached_notice_for, check_for_update_for, current_version, UpdateCheck,
+};
 use tempfile::tempdir;
 
 fn write_cache(home: &std::path::Path, latest: &str) {
+    write_cache_with_time(home, latest, 0);
+}
+
+fn write_fresh_cache(home: &std::path::Path, latest: &str) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    write_cache_with_time(home, latest, now);
+}
+
+fn write_cache_with_time(home: &std::path::Path, latest: &str, checked_at: u64) {
     let dir = home.join(".forgeguard");
     fs::create_dir_all(&dir).expect("create cache dir");
     fs::write(
         dir.join("update-check.json"),
-        format!("{{\"checked_at\":0,\"latest\":\"{latest}\"}}"),
+        format!("{{\"checked_at\":{checked_at},\"latest\":\"{latest}\"}}"),
     )
     .expect("write cache");
 }
@@ -43,4 +57,52 @@ fn cached_notice_uses_the_supplied_binary_version() {
     write_cache(home.path(), "0.11.2");
 
     assert!(cached_notice_for(home.path(), "0.11.2").is_none());
+}
+
+#[test]
+fn check_for_update_returns_structured_info_when_newer() {
+    let home = tempdir().expect("temp home");
+    write_fresh_cache(home.path(), "1.0.0");
+
+    let check = check_for_update_for(home.path(), false, "0.14.0").expect("check result");
+    assert_eq!(
+        check,
+        UpdateCheck {
+            current: "0.14.0".to_owned(),
+            latest: "1.0.0".to_owned(),
+            update_available: true,
+        }
+    );
+}
+
+#[test]
+fn check_for_update_returns_structured_info_when_up_to_date() {
+    let home = tempdir().expect("temp home");
+    write_fresh_cache(home.path(), "0.14.0");
+
+    let check = check_for_update_for(home.path(), false, "0.14.0").expect("check result");
+    assert_eq!(
+        check,
+        UpdateCheck {
+            current: "0.14.0".to_owned(),
+            latest: "0.14.0".to_owned(),
+            update_available: false,
+        }
+    );
+}
+
+#[test]
+fn check_for_update_returns_structured_info_when_ahead_of_latest() {
+    let home = tempdir().expect("temp home");
+    write_fresh_cache(home.path(), "0.13.0");
+
+    let check = check_for_update_for(home.path(), false, "0.14.0").expect("check result");
+    assert_eq!(
+        check,
+        UpdateCheck {
+            current: "0.14.0".to_owned(),
+            latest: "0.13.0".to_owned(),
+            update_available: false,
+        }
+    );
 }


### PR DESCRIPTION
## Summary
- `forgeguard update` now installs a newer release directly instead of only printing a notice.
- Background refreshes (`spawn_refresh_if_stale`) are pinned to `--check` so hooks never trigger an unintended in-place install.
- Adds a structured `UpdateCheck` query so check-only and install paths share one code path.

## Changes
- **core** (`crates/forgeguard-core`):
  - New `UpdateCheck` struct and `check_for_update(_for)` helpers returning `{current, latest, update_available}`.
  - `refresh_for` now derives its notice from the structured check.
  - `spawn_refresh_if_stale` invokes `update --check` (check-only, never installs).
  - `run_install_command` gains a Windows `powershell` branch mirroring `install.ps1`.
- **cli** (`crates/forgeguard-cli`):
  - `update` (no flags): checks the remote, then runs the installer when a newer release exists; reports success/failure with proper exit codes.
  - `update --check`: check-only, prints availability (plus `--json` output with `status`/`current`/`latest`).
  - `--mode`, `--global`, `--json` behavior unchanged.
- **tests**: unit tests for `UpdateCheck` variants (newer / equal / ahead), cache freshness helper.
- **docs**: README "Updating" section rewritten for the new behavior.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --locked --workspace` (172 passed)
- [x] `cargo build --locked --workspace --release`
- [x] `sh tests/install_test.sh`
- [x] Manual smoke: `forgeguard update --check`, `update --check --json`, `update`, `update --json` on an up-to-date install