### PR TITLE
fix(ci): stop labeler overwriting org triage labels

### DIFF
--- a/.github/workflows/suiflex.yml
+++ b/.github/workflows/suiflex.yml
@@ -1,13 +1,19 @@
 name: PR Triage
 
-# Everything that labels a pull request, in one place. Two jobs because they
-# own different things:
+# Two jobs because they own different things, and they MUST run in order:
 #
 #   triage — a thin caller into the organization's shared workflow, so that
 #            every repository in suiflex marks authorship and conventional-commit
 #            types the same way and a change to that lands once, upstream.
 #   label  — this repository's own path -> area map (.github/labeler.yml), which
 #            is specific to this workspace's layout and has no business upstream.
+#
+# The `needs` is not cosmetic: actions/labeler writes the full label set with
+# a single "set labels" call, replacing whatever it read at start. Run the
+# jobs in parallel and the labeler's read can race the triage job's writes,
+# and its PUT then erases the org labels (bot, maintainer, commit: *) that
+# were applied a second earlier — observed on PR #66. Serializing makes the
+# labeler's read happen after triage is done.
 #
 # Both label as suiflex-bot, so a pull request never shows two identities doing
 # the same job.
@@ -38,6 +44,9 @@ jobs:
       private_key: ${{ secrets.SUIFLEX_BOT_PRIVATE_KEY }}
 
   label:
+    # Serialize on triage: labeler replaces the whole label set in one write,
+    # so it must read only after triage finished applying its labels.
+    needs: triage
     # Forks of this repository have their own labels, if any.
     if: github.repository_owner == 'suiflex'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The `label` and `triage` jobs in `suiflex.yml` run in parallel on `pull_request_target`, and both write labels. `actions/labeler` replaces the whole label set in one `setLabels` (PUT) call based on a snapshot read at start, so it can erase the org labels (`bot`, `maintainer`, `commit: *`, `needs: conventional commit`) that the triage job applied seconds earlier.
- Observed on PR #66: timeline shows `maintainer` + 4 `commit: *` labels applied at 17:24:29Z, then unlabeled at 17:24:30Z by the labeler's PUT, leaving only the `area: *` labels.

## Changes
- `label` job now declares `needs: triage` so its read happens after the org labels are applied; area labels layer on top instead of overwriting.
- Comments updated to document the write semantics so nobody "tidies" the `needs` away.

## Test plan
- [x] YAML validated locally (`ruby -ryaml`).
- [ ] After merge: open/update a PR from a maintainer with conventional commits and confirm both `commit: *`/`maintainer` and `area: *` labels survive.
- [ ] Confirm synchronize re-runs still reconcile both label sets correctly.