### PR TITLE
ci: sync review.yml with the organization template

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -34,3 +34,4 @@ jobs:
       model_url: ${{ secrets.GUARDENER_MODEL_URL }}
       model_key: ${{ secrets.GUARDENER_MODEL_KEY }}
       model: ${{ secrets.GUARDENER_MODEL }}
+      model_vomit: ${{ secrets.GUARDENER_MODEL_VOMIT }}


### PR DESCRIPTION
Brings `.github/workflows/review.yml` back in line with `templates/workflows/review.yml` in suiflex/Guardener. Opened by `scripts/sync-stubs.sh`; the diff is the whole change.